### PR TITLE
WIP/Proposal: ThemeProvider sets CSS custom properties for themeable styles

### DIFF
--- a/kitchensink/.babelrc
+++ b/kitchensink/.babelrc
@@ -1,10 +1,6 @@
 {
     "presets": [
-      ["@babel/preset-env", {
-        "targets": {
-          "browsers": [ ">0.1%", "ie 11", "not op_mini all"]
-        }
-      }],
+      "@babel/preset-env",
       "@babel/preset-react"
     ],
     "plugins": [

--- a/kitchensink/.browserslistrc
+++ b/kitchensink/.browserslistrc
@@ -1,4 +1,4 @@
 # Browsers that we support
 
-Last 5 versions
-IE 11 # sorry
+defaults
+not IE 11 # yeah

--- a/kitchensink/.postcssrc
+++ b/kitchensink/.postcssrc
@@ -1,7 +1,6 @@
 {
   "plugins": {
     "postcss-import": {},
-    "postcss-custom-properties": {},
     "autoprefixer": {},
     "postcss-nesting": {}
   }

--- a/kitchensink/package-lock.json
+++ b/kitchensink/package-lock.json
@@ -5920,12 +5920,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-url-superb": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
-      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
-      "dev": true
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -7167,15 +7161,6 @@
         "source-map-js": "^0.6.2"
       }
     },
-    "postcss-custom-properties": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz",
-      "integrity": "sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==",
-      "dev": true,
-      "requires": {
-        "postcss-values-parser": "^4.0.0"
-      }
-    },
     "postcss-import": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.0.2.tgz",
@@ -7278,51 +7263,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
-    },
-    "postcss-values-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
-      "integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.1.4",
-        "is-url-superb": "^4.0.0",
-        "postcss": "^7.0.5"
-      },
-      "dependencies": {
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/kitchensink/package.json
+++ b/kitchensink/package.json
@@ -64,7 +64,6 @@
     "mini-css-extract-plugin": "^1.6.2",
     "object-hash": "^2.2.0",
     "postcss": "^8.3.5",
-    "postcss-custom-properties": "^11.0.0",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.1.0",
     "postcss-nesting": "^8.0.1",

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { ThemeProvider } from '@osag/pyrene';
 import styles from '../../css/componentPage.css';
 import CodeBlock from './CodeBlock';
 import Utils from './Utils';
@@ -101,9 +102,11 @@ export default class ComponentEditor extends React.Component {
           <div className={clsx(styles.displayContainer, { [styles.pinned]: pinned, [styles.darkMode]: darkMode })}>
             <div className={clsx(styles.pin, { [styles.pinned]: pinned })} onClick={() => this.handlePinClick()} />
             <div className={clsx(styles.sun, { [styles.darkMode]: darkMode })} onClick={() => this.handleSunClick()} />
-            <div className={styles.componentDisplay}>
-              {this.props.examples.trigger ? <ParentButton component={displayedComponent} /> : displayedComponent}
-            </div>
+            <ThemeProvider colors={{ text: this.state.darkMode ? '#dbe7ff' : '#1d273b' }}>
+              <div className={styles.componentDisplay}>
+                {this.props.examples.trigger ? <ParentButton component={displayedComponent} /> : displayedComponent}
+              </div>
+            </ThemeProvider>
             <CodeBlock
               component={displayedComponent}
               componentOrigin={this.props.componentOrigin}

--- a/pyrene-graphs/.browserslistrc
+++ b/pyrene-graphs/.browserslistrc
@@ -1,4 +1,4 @@
 # Browsers that we support
 
-Last 5 versions
-IE 11 # sorry
+defaults
+not IE 11 # yeah

--- a/pyrene-graphs/.postcssrc
+++ b/pyrene-graphs/.postcssrc
@@ -3,9 +3,6 @@
   "plugins": {
     "postcss-import": {},
     "postcss-nesting": {},
-    "autoprefixer": {},
-    "postcss-custom-properties": {
-      "preserve": false
-    }
+    "autoprefixer": {}
   }
 }

--- a/pyrene-graphs/package-lock.json
+++ b/pyrene-graphs/package-lock.json
@@ -7555,12 +7555,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "is-url-superb": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
-      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
-      "dev": true
-    },
     "is-yarn-global": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -10454,15 +10448,6 @@
         "source-map-js": "^0.6.2"
       }
     },
-    "postcss-custom-properties": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz",
-      "integrity": "sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==",
-      "dev": true,
-      "requires": {
-        "postcss-values-parser": "^4.0.0"
-      }
-    },
     "postcss-import": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.0.2.tgz",
@@ -10565,51 +10550,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
-    },
-    "postcss-values-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
-      "integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.1.4",
-        "is-url-superb": "^4.0.0",
-        "postcss": "^7.0.5"
-      },
-      "dependencies": {
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.35",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-          "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/pyrene-graphs/package.json
+++ b/pyrene-graphs/package.json
@@ -73,7 +73,6 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.28",
     "postcss": "^8.3.5",
-    "postcss-custom-properties": "^11.0.0",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.1.0",
     "postcss-nesting": "^8.0.1",

--- a/pyrene/.browserslistrc
+++ b/pyrene/.browserslistrc
@@ -1,4 +1,4 @@
 # Browsers that we support
 
-Last 5 versions
-IE 11 # sorry
+defaults
+not IE 11 # yeah

--- a/pyrene/.postcssrc
+++ b/pyrene/.postcssrc
@@ -3,9 +3,6 @@
   "plugins": {
     "postcss-import": {},
     "postcss-nesting": {},
-    "autoprefixer": {},
-    "postcss-custom-properties": {
-      "preserve": false
-    }
+    "autoprefixer": {}
   }
 }

--- a/pyrene/package-lock.json
+++ b/pyrene/package-lock.json
@@ -16627,12 +16627,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "is-url-superb": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
-      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
-      "dev": true
-    },
     "is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
@@ -21355,15 +21349,6 @@
         "source-map-js": "^0.6.2"
       }
     },
-    "postcss-custom-properties": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz",
-      "integrity": "sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==",
-      "dev": true,
-      "requires": {
-        "postcss-values-parser": "^4.0.0"
-      }
-    },
     "postcss-flexbugs-fixes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
@@ -21503,51 +21488,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
-    },
-    "postcss-values-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
-      "integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.1.4",
-        "is-url-superb": "^4.0.0",
-        "postcss": "^7.0.5"
-      },
-      "dependencies": {
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -21983,7 +21923,7 @@
     },
     "react": {
       "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "resolved": "https://repo-java.open.ch/repository/npm/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "requires": {

--- a/pyrene/package.json
+++ b/pyrene/package.json
@@ -84,7 +84,6 @@
     "jest-bamboo-formatter": "^1.0.1",
     "mini-css-extract-plugin": "^1.6.2",
     "postcss": "^8.3.5",
-    "postcss-custom-properties": "^11.0.0",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.1.0",
     "postcss-nesting": "^8.0.1",

--- a/pyrene/src/components/Heading/heading.css
+++ b/pyrene/src/components/Heading/heading.css
@@ -36,7 +36,7 @@
   composes: commonFontSettings from '../../styles/common.module.css';
 
   font-weight: 500;
-  color: var(--neutral-500);
+  color: var(--text);
 
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/pyrene/src/components/ThemeProvider/ThemeProvider.spec.jsx
+++ b/pyrene/src/components/ThemeProvider/ThemeProvider.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ThemeProvider, { themePropertyToCssCustomProperty, themePropertiesToStyles } from './ThemeProvider';
+
+
+describe('themePropertyToCssCustomProperty', () => {
+  it('prepends --', () => {
+    expect(themePropertyToCssCustomProperty('test')).toBe('--test');
+  });
+
+  it('changes camelcase', () => {
+    expect(themePropertyToCssCustomProperty('testProp')).toBe('--test-prop');
+  });
+
+});
+
+describe('themePropertiesToStyles', () => {
+  it('changes theme property to style', () => {
+    expect(themePropertiesToStyles({
+      primaryColor: 'black',
+    })).toStrictEqual({
+      '--primary-color': 'black',
+    });
+  });
+
+});
+
+
+describe('<ThemeProvider />', () => {
+
+  it('renders without crashing', () => {
+    shallow(<ThemeProvider colors={{ primary: 'black' }}><span /></ThemeProvider>);
+  });
+});

--- a/pyrene/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/pyrene/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+/**
+ * Custimizable colors.
+ *
+ */
+export interface Colors extends ThemeProperties {
+  backgroundLight?: string
+  backgroundTint?: string;
+  border?: string;
+  text?: string;
+  icon?: string;
+  iconLight?: string;
+  primary?: string;
+  primaryDark?: string;
+  secondary?: string;
+  secondaryDark?: string;
+}
+
+/**
+ * All theme properties are a flat map of name to string.
+ * (this will not entirely true anymore if we support more than colours).
+ */
+export interface ThemeProperties {
+  [property: string]: string | undefined
+}
+
+/**
+ * Changes camelCaseProperties to --css-variable-style names.
+ *
+ * @param key a theme key
+ * @returns a css variable
+ */
+export const themePropertyToCssCustomProperty = (key: string) : string => `--${key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)}`;
+
+/**
+ * Transfers theme properties to CSS styles (custom properties).
+ *
+ * @param themeProperties properties of a theme, e.g., colors
+ * @returns object with CSS styles
+ */
+export const themePropertiesToStyles = (themeProperties : ThemeProperties) : ThemeProperties => Object.entries(themeProperties)
+  .reduce((cssProperties, [key, value]) => ({ ...cssProperties, [themePropertyToCssCustomProperty(key)]: value }), {});
+
+
+/**
+ * Multiple grouped theme properties (e.g. colors) can be passed to ThemeProvicer.
+ */
+export interface ThemeProviderProps {
+  colors: Colors
+  children: React.ReactNode
+}
+
+/*
+ * Provides CSS variables to all nested components.
+ */
+const ThemeProvider = ({ colors, children }: ThemeProviderProps) : React.ReactElement => (
+  <div style={themePropertiesToStyles(colors)}>
+    {children}
+  </div>
+);
+
+export default ThemeProvider;

--- a/pyrene/src/index.ts
+++ b/pyrene/src/index.ts
@@ -175,4 +175,6 @@ export type SingleSelectOption<ValueType> = _SingleSelectOption<ValueType>;
 
 export { default as colorConstants } from './styles/colorConstants';
 
+export { default as ThemeProvider } from './components/ThemeProvider/ThemeProvider';
+
 export default Components;

--- a/tuktuktwo/.browserslistrc
+++ b/tuktuktwo/.browserslistrc
@@ -1,4 +1,4 @@
 # Browsers that we support
 
-Last 5 versions
-IE 11 # sorry
+defaults
+not IE 11 # yeah

--- a/tuktuktwo/.postcssrc
+++ b/tuktuktwo/.postcssrc
@@ -3,9 +3,6 @@
   "plugins": {
     "postcss-import": {},
     "postcss-nesting": {},
-    "autoprefixer": {},
-    "postcss-custom-properties": {
-      "preserve": false
-    }
+    "autoprefixer": {}
   }
 }


### PR DESCRIPTION
This is a proposal rather than the full implementation:

https://user-images.githubusercontent.com/549158/114041215-a0741800-9884-11eb-866d-877e6c0c249f.mov


Basic idea:

1. CSS custom properties (a.k.a. variables) can be used natively in supported browsers
2. `ThemeProvider` provides those variables for all components to use (most components already use them)
3. For the time being, we should keep `colors.css` which is basically "the default values", which also means that pyrene keeps working as is without theme provider

Next steps:
1. Both default theme and dark theme should be provided as exported constants
2. Investigate color constants / colors.css and how duplication can be reduced once we have ThemeProvider

What do you think?