### PR TITLE
clsx for classnames in Pyrene subproject

### DIFF
--- a/pyrene/package-lock.json
+++ b/pyrene/package-lock.json
@@ -2716,12 +2716,6 @@
         "@types/node": "*"
       }
     },
-    "@types/classnames": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
-      "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
-      "dev": true
-    },
     "@types/enzyme": {
       "version": "3.10.8",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.8.tgz",
@@ -4881,6 +4875,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",

--- a/pyrene/package.json
+++ b/pyrene/package.json
@@ -43,7 +43,6 @@
     "@osag/eslint-config": "^1.4.0",
     "@release-it/bumper": "^2.0.0",
     "@svgr/webpack": "^5.5.0",
-    "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.7",
     "@types/jest": "^26.0.14",
     "@types/react": "^16.9.50",
@@ -96,7 +95,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
+    "clsx": "^1.1.1",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.1.4",
     "prop-types": "^15.6.1",

--- a/pyrene/src/components/Accordion/Section.tsx
+++ b/pyrene/src/components/Accordion/Section.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Icon, { IconProps } from '../Icon/Icon';
 import './accordion.css';
 
@@ -31,7 +31,7 @@ const Section: React.FC<SectionProps> = ({
   const [expanded, setExpanded] = useState(initiallyExpanded);
 
   return (
-    <div styleName={classNames('section', { expanded, collapsed: !expanded })}>
+    <div styleName={clsx('section', { expanded, collapsed: !expanded })}>
       <div styleName="header" onClick={() => setExpanded(!expanded)}>
         {iconProps && <span styleName="icon"><Icon {...iconProps} type="inline" /></span>}
 

--- a/pyrene/src/components/ActionBar/ActionBar.tsx
+++ b/pyrene/src/components/ActionBar/ActionBar.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React, { useState } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Icon from '../Icon/Icon';
 import Loader from '../Loader/Loader';
 import Tooltip from '../Tooltip/Tooltip';
@@ -120,7 +120,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
   }
   return (
     <div
-      styleName={classNames(
+      styleName={clsx(
         `container-${orientation}`,
         disabled && !loading ? 'disabled' : '',
         styling === 'none' ? '' : `box-${styling}`,
@@ -131,7 +131,7 @@ const ActionBar: React.FC<ActionBarProps> = ({
           const isSvgIcon = action.svg && action.svg.length > 0;
           const iconComponent = (
             <div
-              styleName={classNames('iconBox', { disabled: !action.active })}
+              styleName={clsx('iconBox', { disabled: !action.active })}
               onClick={() => handleOnClick(
                 action.renderPopover,
                 action.onClick,

--- a/pyrene/src/components/Badge/Badge.tsx
+++ b/pyrene/src/components/Badge/Badge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import className from 'classnames';
+import clsx from 'clsx';
 
 import './badge.css';
 
@@ -33,11 +33,11 @@ const Badge: React.FC<BadgeProps> = ({
   label, maxWidth, onClick = () => null, type,
 }: BadgeProps) => (
   <div
-    styleName={className('badge', { [`type-${type}`]: true })}
+    styleName={clsx('badge', { [`type-${type}`]: true })}
     style={{ maxWidth: maxWidth }}
     onClick={onClick}
   >
-    <div styleName={className('label')}>
+    <div styleName={clsx('label')}>
       {label}
     </div>
   </div>

--- a/pyrene/src/components/Banner/Banner.tsx
+++ b/pyrene/src/components/Banner/Banner.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import className from 'classnames';
+import clsx from 'clsx';
 
 import Loader from '../Loader/Loader';
 
@@ -48,7 +47,7 @@ const Banner: React.FC<BannerProps> = ({
   type,
 }: BannerProps) => (
   <div
-    styleName={className('banner', `type-${type}`, `style-${styling}`)}
+    styleName={clsx('banner', `type-${type}`, `style-${styling}`)}
     role="banner"
   >
     <div styleName="iconMessageContainer">

--- a/pyrene/src/components/Button/Button.tsx
+++ b/pyrene/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './button.css';
 import Loader from '../Loader/Loader';
@@ -53,7 +53,7 @@ const Button: React.FC<ButtonProps> = ({
       type="submit"
       className="unSelectable"
       styleName={
-        classNames('button',
+        clsx('button',
           { [`type-${type}`]: true },
           { disabled: disabled },
           { loading: loading })

--- a/pyrene/src/components/ButtonBar/ButtonBar.tsx
+++ b/pyrene/src/components/ButtonBar/ButtonBar.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './buttonBar.css';
 import { ButtonProps } from '../Button/Button';
 
@@ -14,7 +14,7 @@ const ButtonBar: React.FC<ButtonBarProps> = ({
   leftButtonSectionElements = [],
   rightButtonSectionElements = [],
 }: ButtonBarProps) => (
-  <div styleName={classNames('buttonBar', { noPadding: noPadding })}>
+  <div styleName={clsx('buttonBar', { noPadding: noPadding })}>
     <div styleName="leftButtonSection">
       {leftButtonSectionElements.map((element) => (
         <React.Fragment key={`${element.props.type || 'undefined'}-${element.props.label as string}`}>

--- a/pyrene/src/components/Card/Card.tsx
+++ b/pyrene/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import Loader from '../Loader/Loader';
 import Banner from '../Banner/Banner';
@@ -43,7 +43,7 @@ const Card:React.FC<CardProps> = ({
 
   <div styleName="container">
     {header && <div styleName="header">{header}</div>}
-    <div styleName={classNames('content', { 'content--noHeader': !header, 'content--noFooter': !footer })}>
+    <div styleName={clsx('content', { 'content--noHeader': !header, 'content--noFooter': !footer })}>
       {/* eslint-disable-next-line no-nested-ternary */}
       { error ? <div styleName="error"><Banner type="error" styling="standard" label={error} /></div>
         : loading ? (

--- a/pyrene/src/components/Checkbox/Checkbox.tsx
+++ b/pyrene/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Tooltip from '../Tooltip/Tooltip';
 import './checkbox.css';
 
@@ -148,7 +148,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
       />
       <label
         className="unSelectable"
-        styleName={classNames('checkboxLabel', { disabled: disabled, required: required })}
+        styleName={clsx('checkboxLabel', { disabled: disabled, required: required })}
         htmlFor={`checkbox_${label}_${rand}`}
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
         role="checkbox"

--- a/pyrene/src/components/CheckboxPopover/CheckboxPopover.jsx
+++ b/pyrene/src/components/CheckboxPopover/CheckboxPopover.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './checkboxPopover.css';
 import Popover from '../Popover/Popover';
@@ -24,7 +24,7 @@ export default class CheckboxPopover extends React.Component {
 
   render() {
     return (
-      <div styleName={classNames('checkboxPopover', { disabled: this.props.disabled })}>
+      <div styleName={clsx('checkboxPopover', { disabled: this.props.disabled })}>
         <Popover
           preferredPosition={['bottom']}
           align="end"
@@ -33,7 +33,7 @@ export default class CheckboxPopover extends React.Component {
           onClickOutside={() => this.setState({ displayPopover: false })}
           renderPopoverContent={() => <CheckboxList listItems={this.props.listItems} onItemClick={this.props.onItemClick} onRestoreDefault={this.props.onRestoreDefault} />}
         >
-          <div styleName={classNames('popoverTriggerButton', { popoverOpen: this.state.displayPopover })} onClick={this.togglePopover}>
+          <div styleName={clsx('popoverTriggerButton', { popoverOpen: this.state.displayPopover })} onClick={this.togglePopover}>
             <div styleName="buttonLabel" className="unSelectable">
               {this.props.buttonLabel}
             </div>

--- a/pyrene/src/components/Collapsible/Collapsible.tsx
+++ b/pyrene/src/components/Collapsible/Collapsible.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './collapsible.css';
 
@@ -66,8 +66,8 @@ const Collapsible: React.FC<CollapsibleProps> = ({
   };
 
   return (
-    <div styleName={classNames('collapsibleBox', { expanded })}>
-      <div styleName={classNames('buttonAlignmentBox', { [`align-${align}`]: true })}>
+    <div styleName={clsx('collapsibleBox', { expanded })}>
+      <div styleName={clsx('buttonAlignmentBox', { [`align-${align}`]: true })}>
         <div styleName="collapsibleButton" className="unSelectable" onClick={(event:React.MouseEvent) => toggleCollapse(event)} role="button" aria-label="Show or hide content">
           <div styleName="centeringBox">
             <span styleName="label">

--- a/pyrene/src/components/Container/Container.jsx
+++ b/pyrene/src/components/Container/Container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './container.css';
 
@@ -37,8 +37,8 @@ export default class Container extends React.Component {
 
   render() {
     return (
-      <div styleName={classNames('container', { expanded: this.state.expanded || !this.props.collapsible })}>
-        <div styleName={classNames('header', { collapsible: this.props.collapsible })} onClick={this.toggleCollapse} role="button" aria-label="Show or hide container">
+      <div styleName={clsx('container', { expanded: this.state.expanded || !this.props.collapsible })}>
+        <div styleName={clsx('header', { collapsible: this.props.collapsible })} onClick={this.toggleCollapse} role="button" aria-label="Show or hide container">
           <span styleName="title" className="unSelectable">
             {' '}
             {this.props.title}

--- a/pyrene/src/components/DropdownButton/DropdownButton.jsx
+++ b/pyrene/src/components/DropdownButton/DropdownButton.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Popover from '../Popover/Popover';
 import OptionsList from './OptionsList';
 import './dropdownButton.css';
@@ -31,7 +31,7 @@ const DropdownButton = (props) => {
         <button
           type="submit"
           styleName={
-            classNames('button',
+            clsx('button',
               { disabled: props.disabled },
               { loading: props.loading },
               { openedDropdown: state.displayActions })

--- a/pyrene/src/components/Filter/FilterComponents/FilterButton.jsx
+++ b/pyrene/src/components/Filter/FilterComponents/FilterButton.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import './filterButton.css';
 
 const FilterButton = (props) => (
-  <div styleName={classNames('filterButton', { noBorder: props.noBorder }, { popoverOpen: props.displayPopover }, { disabled: props.disabled })} onClick={props.onClick}>
+  <div styleName={clsx('filterButton', { noBorder: props.noBorder }, { popoverOpen: props.displayPopover }, { disabled: props.disabled })} onClick={props.onClick}>
     <div styleName="buttonLabel">
       {props.label}
     </div>
-    <div styleName="arrowIcon" className={classNames(props.displayPopover ? 'pyreneIcon-chevronUp' : 'pyreneIcon-chevronDown')} />
+    <div styleName="arrowIcon" className={clsx(props.displayPopover ? 'pyreneIcon-chevronUp' : 'pyreneIcon-chevronDown')} />
   </div>
 );
 

--- a/pyrene/src/components/Heading/Heading.tsx
+++ b/pyrene/src/components/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './heading.css';
 
@@ -21,7 +21,7 @@ const Heading: React.FC<HeadingProps> = ({
   children,
   level = 1,
 }: HeadingProps) => (
-  <div styleName={classNames(`heading${level}`, 'heading')} title={children}>
+  <div styleName={clsx(`heading${level}`, 'heading')} title={children}>
     {children}
   </div>
 );

--- a/pyrene/src/components/Icon/Icon.tsx
+++ b/pyrene/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import colorConstants from '../../styles/colorConstants';
 import './icon.css';
 
@@ -33,12 +33,12 @@ const Icon: React.FC<IconProps> = ({
   svg = '',
 }: IconProps) => (
   svg.length > 0 ? (
-    <div styleName={classNames('icon', `type-${type}`)}>
+    <div styleName={clsx('icon', `type-${type}`)}>
       <img styleName="svgIcon" src={svg} alt="icon" />
     </div>
   ) : (
     <div
-      styleName={classNames('icon', `type-${type}`)}
+      styleName={clsx('icon', `type-${type}`)}
       className={`pyreneIcon-${name}`}
       style={{ color: color in colorConstants ? colorConstants[color as keyof typeof colorConstants] : color }}
     />

--- a/pyrene/src/components/IconButton/IconButton.tsx
+++ b/pyrene/src/components/IconButton/IconButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './iconbutton.css';
 
 export interface IconButtonProps {
@@ -35,7 +35,7 @@ const IconButton: React.FC<IconButtonProps> = ({
   path = '#',
   type = 'neutral',
 }: IconButtonProps) => (
-  <a styleName={classNames('iconButton', { disabled: disabled }, { [`type-${type}`]: true })}
+  <a styleName={clsx('iconButton', { disabled: disabled }, { [`type-${type}`]: true })}
     href={path}
     onClick={
       onClick ? ((event) => {

--- a/pyrene/src/components/LabelAndValue/LabelAndValue.tsx
+++ b/pyrene/src/components/LabelAndValue/LabelAndValue.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import className from 'classnames';
+import clsx from 'clsx';
 
 import './labelAndValue.css';
 
@@ -30,7 +30,7 @@ const LabelAndValue: React.FC<LabelAndValueProps> = ({
 }: LabelAndValueProps) => (
   <div styleName={`label-and-value label-and-value-${size}`}>
     <div styleName="label">{label}</div>
-    <div styleName={className('value', { [`type-${type}`]: true })}>{value}</div>
+    <div styleName={clsx('value', { [`type-${type}`]: true })}>{value}</div>
   </div>
 );
 

--- a/pyrene/src/components/Link/Link.jsx
+++ b/pyrene/src/components/Link/Link.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './link.css';
 
@@ -15,7 +15,7 @@ import './link.css';
  */
 const Link = (props) => (
   <a
-    styleName={classNames('link', { [`type-${props.type}`]: true }, { disabled: props.disabled })}
+    styleName={clsx('link', { [`type-${props.type}`]: true }, { disabled: props.disabled })}
     href={props.path}
     onClick={props.onClick ? ((event) => {
       event.preventDefault();

--- a/pyrene/src/components/Loader/Loader.tsx
+++ b/pyrene/src/components/Loader/Loader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './loader.css';
 
@@ -37,13 +37,13 @@ const Loader: React.FC<LoaderProps> = ({
   <>
     {type === 'standalone'
       && (
-        <div styleName={classNames('canvas', { [`size-${size}`]: true })}>
-          <div styleName={classNames('standaloneLoader', { [`styling-${styling}`]: true }, { [`size-${size}`]: true })} />
+        <div styleName={clsx('canvas', { [`size-${size}`]: true })}>
+          <div styleName={clsx('standaloneLoader', { [`styling-${styling}`]: true }, { [`size-${size}`]: true })} />
         </div>
       )}
     {type === 'inline'
       && (
-        <span styleName={classNames('inlineLoader')} />
+        <span styleName={clsx('inlineLoader')} />
       )}
   </>
 );

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './modal.css';
 import ButtonBar from '../ButtonBar/ButtonBar';
 import Button, { Type as ButtonType } from '../Button/Button';
@@ -216,8 +216,8 @@ const Modal: React.FC<ModalProps> = ({
 
   const renderContent = () => (
     <>
-      <div styleName={classNames('contentContainer', { contentScrolling: contentScrolling })}>
-        <div styleName={classNames('content', { contentPadding: contentPadding }, { contentScrolling: contentScrolling }, { overlay: processing })}>
+      <div styleName={clsx('contentContainer', { contentScrolling: contentScrolling })}>
+        <div styleName={clsx('content', { contentPadding: contentPadding }, { contentScrolling: contentScrolling }, { overlay: processing })}>
           { renderCallback() }
         </div>
       </div>
@@ -233,7 +233,7 @@ const Modal: React.FC<ModalProps> = ({
   return (
     <>
       <div styleName="modalOverlay">
-        <div styleName={classNames('modalContainer', size)} role="dialog">
+        <div styleName={clsx('modalContainer', size)} role="dialog">
           {renderHeader && renderHeaderSection()}
           {loading ? renderLoader() : renderContent()}
           {renderFooter && renderFooterSection()}

--- a/pyrene/src/components/MultiSelect/MultiSelect.jsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import '../SingleSelect/select.css';
@@ -80,8 +80,8 @@ const MultiSelect = (props) => {
   };
 
   return (
-    <div onPaste={onPaste} styleName={classNames('selectContainer', { disabled: props.disabled })}>
-      {props.title && <div styleName={classNames('selectTitle', { required: props.required && !props.disabled })}>{props.title}</div>}
+    <div onPaste={onPaste} styleName={clsx('selectContainer', { disabled: props.disabled })}>
+      {props.title && <div styleName={clsx('selectTitle', { required: props.required && !props.disabled })}>{props.title}</div>}
       {props.creatable
         ? (
           <CreatableSelect

--- a/pyrene/src/components/MultiSelect/MultiSelectMenuWithOptions.jsx
+++ b/pyrene/src/components/MultiSelect/MultiSelectMenuWithOptions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { components } from 'react-select';
 import './multiSelectMenuWithOptions.css';
 
@@ -11,7 +11,7 @@ const MultiSelectMenuWithOptions = (props) => (
     {props.getValue().length > 0 && (
       <div styleName="selectMenuWithOptions">
         {props.getValue().map((option) => (
-          <div styleName={classNames('selectOption', { invalid: option.invalid })} key={option.value}>
+          <div styleName={clsx('selectOption', { invalid: option.invalid })} key={option.value}>
             <div styleName="optionLabel">{option.label}</div>
             <div styleName="clearBox" onClick={() => props.setValue(props.getValue().filter((e) => e !== option))}>
               <div styleName="clearIcon" className="pyreneIcon-delete" />

--- a/pyrene/src/components/Pill/Pill.tsx
+++ b/pyrene/src/components/Pill/Pill.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import className from 'classnames';
+import clsx from 'clsx';
 
 import IconButton from '../IconButton/IconButton';
 
@@ -51,15 +50,15 @@ const Pill: React.FC<PillProps> = ({
 }: PillProps) => (
   <div>
     {(onClick && icon)
-      && <div styleName={className('icon')}><IconButton icon={icon} type={iconType} onClick={onClick} /></div>}
+      && <div styleName={clsx('icon')}><IconButton icon={icon} type={iconType} onClick={onClick} /></div>}
     {(!onClick && icon) && (
-      <div styleName={className('icon', { [`type-${iconType}`]: true })}>
+      <div styleName={clsx('icon', { [`type-${iconType}`]: true })}>
         <span className={`pyreneIcon-${icon}`} />
       </div>
     )}
     {!maxValue || (value <= maxValue)
-      ? <div styleName={className('pill', { [`type-${type}`]: true })}>{value}</div>
-      : <div styleName={className('pill', { [`type-${type}`]: true })}>{`${maxValue}+`}</div>}
+      ? <div styleName={clsx('pill', { [`type-${type}`]: true })}>{value}</div>
+      : <div styleName={clsx('pill', { [`type-${type}`]: true })}>{`${maxValue}+`}</div>}
   </div>
 );
 

--- a/pyrene/src/components/RadioButton/RadioButton.tsx
+++ b/pyrene/src/components/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './radioSelection.css';
 
@@ -126,7 +126,7 @@ const RadioButton: React.FC<RadioButtonProps> = ({
       <label
         htmlFor={id != null ? id : htmlId}
         styleName={
-          classNames('radioLabel',
+          clsx('radioLabel',
             { disabled: disabled })
         }
       >

--- a/pyrene/src/components/RadioGroup/RadioGroup.tsx
+++ b/pyrene/src/components/RadioGroup/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import RadioButton, { RadioButtonBaseProps } from '../RadioButton/RadioButton';
 
@@ -84,7 +84,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
       id={name}
     >
       {title && <div styleName="radioGroupTitle">{title}</div>}
-      <div styleName={classNames('radioGroupContainer', { [`alignment-${alignment}`]: true })}>
+      <div styleName={clsx('radioGroupContainer', { [`alignment-${alignment}`]: true })}>
         {options.map((option, index) => {
           const key = `radio_${option.label ?? ''}_${option.value}`;
 
@@ -107,7 +107,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
                   value={option.value}
                 />
               </div>
-              {index !== lastElementIndex && <div styleName={classNames({ [`spacer-${alignment}`]: true })} />}
+              {index !== lastElementIndex && <div styleName={clsx({ [`spacer-${alignment}`]: true })} />}
             </React.Fragment>
           );
         })}

--- a/pyrene/src/components/RadioPopover/OptionList.jsx
+++ b/pyrene/src/components/RadioPopover/OptionList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './optionList.css';
 
@@ -17,11 +17,11 @@ const OptionList = (props) => (
           const selected = item === props.selectedValue;
           return (
             <div
-              styleName={classNames('listItem', { selected })}
+              styleName={clsx('listItem', { selected })}
               key={item.value}
               onClick={() => props.onChange(item)}
             >
-              <span className={classNames({ 'pyreneIcon-check': selected })} styleName="listIcon" aria-label="Item checked" />
+              <span className={clsx({ 'pyreneIcon-check': selected })} styleName="listIcon" aria-label="Item checked" />
               <span styleName="listLabel">{item.label}</span>
             </div>
           );

--- a/pyrene/src/components/RadioPopover/RadioPopover.jsx
+++ b/pyrene/src/components/RadioPopover/RadioPopover.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './radioPopover.css';
 import Popover from '../Popover/Popover';
@@ -56,7 +56,7 @@ export default class RadioPopover extends React.Component {
             />
           )}
         >
-          <div styleName={classNames('popoverTriggerButton', { popoverOpen: this.state.displayPopover })} onClick={this.togglePopover}>
+          <div styleName={clsx('popoverTriggerButton', { popoverOpen: this.state.displayPopover })} onClick={this.togglePopover}>
             <div styleName="buttonLabel" className="unSelectable">
               {renderLabel(selectedValue)}
             </div>

--- a/pyrene/src/components/SearchFinder/SearchFinder.jsx
+++ b/pyrene/src/components/SearchFinder/SearchFinder.jsx
@@ -1,7 +1,7 @@
 import React, {
   useCallback,
 } from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 import styles from './searchFinder.css';
@@ -58,16 +58,16 @@ const SearchFinder = ({
         placeholder={placeholder}
         extraActionElement={(
           <div className={styles.extraElement}>
-            <div className={classNames(styles.hits, { [styles.disabled]: !searchTerm.length })}>
+            <div className={clsx(styles.hits, { [styles.disabled]: !searchTerm.length })}>
               <span>
                 {`${selectedResult}/${resultCount}`}
               </span>
             </div>
             <div className={styles.separator} />
-            <div className={classNames(styles.icon, { [styles.disabled]: disableResultSelector })} onClick={selectPreviousResult}>
+            <div className={clsx(styles.icon, { [styles.disabled]: disableResultSelector })} onClick={selectPreviousResult}>
               <Icon type="standalone" name="chevronUp" color={disableResultSelector ? 'neutral100' : 'neutral500'} />
             </div>
-            <div className={classNames(styles.icon, { [styles.disabled]: disableResultSelector })} onClick={selectNextResult}>
+            <div className={clsx(styles.icon, { [styles.disabled]: disableResultSelector })} onClick={selectNextResult}>
               <Icon type="standalone" name="chevronDown" color={disableResultSelector ? 'neutral100' : 'neutral500'} />
             </div>
           </div>

--- a/pyrene/src/components/SearchFinder/components/SearchInput/SearchInput.jsx
+++ b/pyrene/src/components/SearchFinder/components/SearchInput/SearchInput.jsx
@@ -2,7 +2,7 @@ import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import styles from './searchInput.css';
 import Icon from '../../../Icon/Icon';
 
@@ -65,12 +65,12 @@ const SearchInput = ({
 
   return (
     <div
-      className={classNames(styles.inputArea, { [styles.isFocused]: isLocalFocused })}
+      className={clsx(styles.inputArea, { [styles.isFocused]: isLocalFocused })}
       style={{ width: width }}
       ref={containerRef}
       onKeyDown={onEnter ? handleEnter : null}
     >
-      <div className={classNames(styles.icon, styles.passive)}>
+      <div className={clsx(styles.icon, styles.passive)}>
         <Icon type="standalone" name="search" />
       </div>
       <input
@@ -84,7 +84,7 @@ const SearchInput = ({
       <div>
         {extraActionElement}
       </div>
-      <div className={classNames(styles.icon, { [styles.disabled]: !value.length })} onClick={clearTerm}>
+      <div className={clsx(styles.icon, { [styles.disabled]: !value.length })} onClick={clearTerm}>
         <Icon type="standalone" name="delete" color={!value.length ? 'neutral100' : 'neutral500'} />
       </div>
     </div>

--- a/pyrene/src/components/SimpleTable/SimpleTable.jsx
+++ b/pyrene/src/components/SimpleTable/SimpleTable.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Loader from '../Loader/Loader';
 import SimpleTableActionList from './SimpleTableActionList';
 import './simpleTable.css';
@@ -30,7 +29,7 @@ const SimpleTable = (props) => (
               {props.actions.length > 0 && (
                 <th
                   aria-label="Action"
-                  styleName={classNames('tableHeaderCell', 'actionCell')}
+                  styleName={clsx('tableHeaderCell', 'actionCell')}
                   key="action"
                 />
               )}
@@ -40,7 +39,7 @@ const SimpleTable = (props) => (
       <tbody styleName="tableBody">
         {!props.loading && props.data && props.data.length > 0 && props.data.map((row, rowIndex) => (
           <tr
-            styleName={classNames('tableRow', (props.onRowClick || props.onRowDoubleClick) ? 'tableRowWithFunction' : '')}
+            styleName={clsx('tableRow', (props.onRowClick || props.onRowDoubleClick) ? 'tableRowWithFunction' : '')}
             key={Object.values(row).join()}
             onDoubleClick={() => (props.onRowDoubleClick ? props.onRowDoubleClick(row) : null)}
             onClick={() => (props.onRowClick ? props.onRowClick(row) : null)}
@@ -62,7 +61,7 @@ const SimpleTable = (props) => (
             })}
             {!props.loading && props.data && props.data.length > 0 && props.actions && props.actions.length > 0 && (
               <td
-                styleName={classNames('tableCell', 'actionCell')}
+                styleName={clsx('tableCell', 'actionCell')}
                 key={`action-${Object.values(row).join('-')}`}
               >
                 <SimpleTableActionList

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Select from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import selectStyle from './selectStyle';
@@ -172,8 +172,8 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
   const optionsObj = getOptionsObj(options, groupedOptions, sorted);
 
   return (
-    <div styleName={classNames('selectContainer', { disabled: disabled })}>
-      {title && <div styleName={classNames('selectTitle', { required: required && !disabled })}>{title}</div>}
+    <div styleName={clsx('selectContainer', { disabled: disabled })}>
+      {title && <div styleName={clsx('selectTitle', { required: required && !disabled })}>{title}</div>}
 
       {creatable
         ? (

--- a/pyrene/src/components/Spacer/Spacer.jsx
+++ b/pyrene/src/components/Spacer/Spacer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './spacer.css';
 
@@ -8,7 +8,7 @@ import './spacer.css';
 * Spacers separate content.
 */
 const Spacer = ({ size }) => (
-  <div styleName={classNames(`spacer-${size}`, 'spacer')} />
+  <div styleName={clsx(`spacer-${size}`, 'spacer')} />
 );
 
 Spacer.displayName = 'Spacer';

--- a/pyrene/src/components/Stepper/Stepper.jsx
+++ b/pyrene/src/components/Stepper/Stepper.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './stepper.css';
 
@@ -17,7 +17,7 @@ const Stepper = (props) => {
       type="button"
       className="unSelectable"
       styleName={
-        classNames('stepper',
+        clsx('stepper',
           { disabled: props.disabled },
           { [`type-${props.type}`]: true })
       }

--- a/pyrene/src/components/TabView/TabView.jsx
+++ b/pyrene/src/components/TabView/TabView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './tabView.css';
 
@@ -80,7 +80,7 @@ export default class TabView extends React.Component {
       </div>
       {moreTabs.map((tab, index) => (
         <div
-          styleName={classNames('option', { disabled: tab.disabled })}
+          styleName={clsx('option', { disabled: tab.disabled })}
           onClick={(event) => !tab.disabled && this._tabChanged(tab.name, index + visibleTabs.length, event)}
           key={tab.name}
           role="option"
@@ -95,12 +95,12 @@ export default class TabView extends React.Component {
     const [visibleTabs, moreTabs] = this.computeTabs();
 
     return (
-      <div styleName={classNames('tabView', { disabled: this.props.disabled })}>
+      <div styleName={clsx('tabView', { disabled: this.props.disabled })}>
         <div styleName="tabBar" role="tablist">
           {
             visibleTabs.map((tab, index) => (
               <div
-                styleName={classNames(
+                styleName={clsx(
                   'tab',
                   { selected: index === this.state.selectedTabIndex },
                   { disabled: tab.disabled },
@@ -119,7 +119,7 @@ export default class TabView extends React.Component {
           && (
             <div
               styleName={
-                classNames(
+                clsx(
                   'moreTab',
                   { displayMenu: this.state.displayMoreMenu },
                   { selected: this.state.selectedTabIndex >= visibleTabs.length },
@@ -143,7 +143,7 @@ export default class TabView extends React.Component {
           )}
         </div>
         {this.props.tabHeaderElement}
-        <div styleName={classNames('tabContent', { withHeader: !!this.props.tabHeaderElement })} role="tabpanel">
+        <div styleName={clsx('tabContent', { withHeader: !!this.props.tabHeaderElement })} role="tabpanel">
           {this.props.tabs[this.state.selectedTabIndex].renderCallback()}
         </div>
 

--- a/pyrene/src/components/Table/Table.jsx
+++ b/pyrene/src/components/Table/Table.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTable from 'react-table';
 import checkboxHOC from 'react-table/lib/hoc/selectTable';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './table.css';
 import TablePagination from './TablePagination/TablePagination';
@@ -355,7 +355,7 @@ export default class Table extends React.Component {
           </div>
         )}
 
-        <div styleName={classNames('filterBar', { loading: this.props.loading, disabled: this.props.disabled })}>
+        <div styleName={clsx('filterBar', { loading: this.props.loading, disabled: this.props.disabled })}>
           <div styleName="filterContainer">
             {(this.props.filters.length > 0 || this.props.filterDisabled)
               && (
@@ -379,7 +379,7 @@ export default class Table extends React.Component {
           )}
         </div>
 
-        <div styleName={classNames('tableAndActions', { disabled: this.props.disabled })}>
+        <div styleName={clsx('tableAndActions', { disabled: this.props.disabled })}>
 
           {this.props.actions.length > 0 && (
             <div styleName="toolbar">

--- a/pyrene/src/components/Table/TableCell/TableCell.jsx
+++ b/pyrene/src/components/Table/TableCell/TableCell.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './tableCell.css';
 
 const TableCell = (props) => (
   <div styleName="tableCell" className="rt-td" role="gridcell" style={props.style} onClick={props.onClick}>
-    <div styleName={classNames('tableData', { multiSelect: props.multiSelect })} style={{ overflow: props.style.overflow }}>{props.children}</div>
+    <div styleName={clsx('tableData', { multiSelect: props.multiSelect })} style={{ overflow: props.style.overflow }}>{props.children}</div>
   </div>
 );
 

--- a/pyrene/src/components/Table/TableHeader/TableHeader.jsx
+++ b/pyrene/src/components/Table/TableHeader/TableHeader.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './tableHeader.css';
 
 const TableHeader = (props) => (
-  <div styleName={classNames('tableHeader', { disabled: props.disabled })}>
+  <div styleName={clsx('tableHeader', { disabled: props.disabled })}>
     {props.children}
   </div>
 );

--- a/pyrene/src/components/Table/TableHeader/TableHeaderCell.jsx
+++ b/pyrene/src/components/Table/TableHeader/TableHeaderCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 // @ts-ignore
 import DefaultSort from '../images/sort.svg';
@@ -26,8 +26,8 @@ const getIconComponent = (className) => {
 const TableHeaderCell = (props) => (
   <div
     onClick={(event) => props.toggleSort(event)}
-    styleName={classNames({ multiSelect: props.multiSelect, tableHeaderCell: true })}
-    className={classNames(props.className, 'unSelectable')}
+    styleName={clsx({ multiSelect: props.multiSelect, tableHeaderCell: true })}
+    className={clsx(props.className, 'unSelectable')}
     style={props.style}
   >
     {props.children}

--- a/pyrene/src/components/Table/TablePagination/TablePagination.jsx
+++ b/pyrene/src/components/Table/TablePagination/TablePagination.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Stepper from '../../Stepper/Stepper';
 import TableSelect from './TableSelect/TableSelect';
 
@@ -44,7 +44,7 @@ const TablePagination = (props) => (
     <div styleName="pageNavigation">
       <Stepper direction="left" disabled={!props.canPrevious || !!props.error} onClick={() => props.onPageChange(props.page - 1)} type="minimal" />
       <div styleName="spacer small" />
-      <div styleName={classNames('pageTracker', { disabled: !!props.error })}>
+      <div styleName={clsx('pageTracker', { disabled: !!props.error })}>
         {props.pages > 0 && !props.error ? `${props.page + 1} of ${props.pages}` : '1 of 1'}
       </div>
       <div styleName="spacer small" />

--- a/pyrene/src/components/Table/TablePagination/TableSelect/TableSelect.jsx
+++ b/pyrene/src/components/Table/TablePagination/TableSelect/TableSelect.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import Select from 'react-select';
 import SelectStyle from './tableSelectCSS';
 import './tableSelect.css';
 
 
 const TableSelect = (props) => (
-  <div styleName={classNames('selectContainer', { disabled: props.disabled })}>
+  <div styleName={clsx('selectContainer', { disabled: props.disabled })}>
     <Select
       className="singleSelect"
       styles={SelectStyle}

--- a/pyrene/src/components/TextArea/TextArea.tsx
+++ b/pyrene/src/components/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './textArea.css';
 
 export interface TextAreaProps {
@@ -97,7 +97,7 @@ const TextArea: React.FC<TextAreaProps> = ({
   return (
     <div
       style={{ width: width }}
-      styleName={classNames(
+      styleName={clsx(
         'textAreaContainer',
         { disabled: disabled },
         { invalid: invalid && !disabled },
@@ -105,11 +105,11 @@ const TextArea: React.FC<TextAreaProps> = ({
       )}
     >
       <div styleName="textAreaTitleBar">
-        {title && <span styleName={classNames('textAreaTitle', { required: required && !disabled })}>{title}</span>}
+        {title && <span styleName={clsx('textAreaTitle', { required: required && !disabled })}>{title}</span>}
         {maxLength > 0 && <span styleName="characterCounter">{characterCount}</span>}
       </div>
       <textarea
-        styleName={classNames('textArea', { resizeable: resizeable }, { filled: value })}
+        styleName={clsx('textArea', { resizeable: resizeable }, { filled: value })}
         name={name}
         placeholder={placeholder}
         rows={rows}

--- a/pyrene/src/components/TextField/TextField.jsx
+++ b/pyrene/src/components/TextField/TextField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './textField.css';
 
 /**
@@ -12,12 +12,12 @@ import './textField.css';
  * In this case, use the date picker, date range selection, or date/time picker. For entering long texts use the textarea component.
  */
 const TextField = (props) => (
-  <div styleName={classNames('textFieldContainer', { disabled: props.disabled }, { invalid: props.invalid && !props.disabled })} style={{ width: (props.width >= 0) ? `${props.width}px` : '100%' }}>
-    {props.title && <div styleName={classNames('textFieldTitle', { required: props.required && !props.disabled })}>{props.title}</div>}
+  <div styleName={clsx('textFieldContainer', { disabled: props.disabled }, { invalid: props.invalid && !props.disabled })} style={{ width: (props.width >= 0) ? `${props.width}px` : '100%' }}>
+    {props.title && <div styleName={clsx('textFieldTitle', { required: props.required && !props.disabled })}>{props.title}</div>}
     <div styleName="textFieldIconLayoutContainer">
 
       <input
-        styleName={classNames('textField', { filled: props.value })}
+        styleName={clsx('textField', { filled: props.value })}
         type={props.secret ? 'password' : 'text'}
         name={props.name}
         placeholder={props.placeholder}

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/ArrowSelector.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/ArrowSelector.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import TRSStepper from './TRSStepper/TRSStepper';
 import './arrowSelector.css';
@@ -15,7 +15,7 @@ const ArrowSelector = (props) => (
     />
     <div styleName="contentOuter">
       <div styleName="contentInner" style={{ width: props.innerWidth }}>
-        <div styleName={classNames('value', { disabled: props.disabled })}>
+        <div styleName={clsx('value', { disabled: props.disabled })}>
           {props.label}
         </div>
       </div>

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/TRSStepper/TRSStepper.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/TRSStepper/TRSStepper.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './trsStepper.css';
 
@@ -15,7 +15,7 @@ const TRSStepper = (props) => {
       type="button"
       className="unSelectable"
       styleName={
-        classNames('stepper',
+        clsx('stepper',
           { disabled: props.disabled },
           { right: props.direction === 'right' },
           { left: props.direction === 'left' })
@@ -24,7 +24,7 @@ const TRSStepper = (props) => {
       disabled={props.disabled}
     >
       <span className={iconName} styleName={
-        classNames('stepperIcon',
+        clsx('stepperIcon',
           { disabledIcon: props.inactive })
       }
       />

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import {
   addMilliseconds, subMilliseconds, getTime, differenceInMilliseconds,
 } from 'date-fns';
-
-import classNames from 'classnames';
+import clsx from 'clsx';
 import PresetTimeRanges from './PresetTimeRanges/PresetTimeRanges';
 import TimeRangeNavigationBar from './TimeRangeNavigationBar/TimeRangeNavigationBar';
 import PRESET_TIME_RANGES from './TimeRangeSelectorDefaultProps';
@@ -111,7 +110,7 @@ export default class TimeRangeSelector extends Component {
     currentTimeRangeType = currentTimeRangeType ? currentTimeRangeType.id : ''; // If we found a match, then let's use the id of the preset, otherwise no default preset has to be selected
 
     return (
-      <div styleName={classNames('timeRangeSelector', { disabled: this.props.disabled })}>
+      <div styleName={clsx('timeRangeSelector', { disabled: this.props.disabled })}>
         <div styleName="timeRangeSelector--left">
           <PresetTimeRanges
             disabled={this.props.disabled}
@@ -135,7 +134,7 @@ export default class TimeRangeSelector extends Component {
             timezone={this.props.timezone}
           />
         </div>
-        <div styleName={classNames('timeRangeSelector--right', { disabled: this.props.disabled })}>
+        <div styleName={clsx('timeRangeSelector--right', { disabled: this.props.disabled })}>
           {this.props.renderRightSection()}
         </div>
       </div>

--- a/pyrene/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/pyrene/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import './toggleButtonGroup.css';
 
 export interface ToggleButtonGroupValue {
@@ -47,14 +47,14 @@ const ToggleButtonGroup: React.FC<ToggleButtonGroupProps> = ({
   value,
 }: ToggleButtonGroupProps) => (
 
-  <div styleName={classNames('toggleButtonGroup', styling === 'shadow' ? 'box-shadow' : null)}>
+  <div styleName={clsx('toggleButtonGroup', styling === 'shadow' ? 'box-shadow' : null)}>
     {options.map((option) => (
       <button
         id={option.value}
         key={option.value}
         type="button"
         styleName={
-          classNames(
+          clsx(
             { disabled: disabled },
             { active: value === option.value },
           )

--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { VariableSizeList as List } from 'react-window';
 
 import './treeTable.css';
@@ -270,7 +270,7 @@ class TreeTable extends React.Component {
 
         {props.loading && renderLoader()}
 
-        <div styleName={classNames({ loading: props.loading })}>
+        <div styleName={clsx({ loading: props.loading })}>
           {props.filters.length > 0 && (
             <div styleName="filterContainer">
               <Filter

--- a/pyrene/src/components/TreeTable/TreeTableCell/TreeTableCell.jsx
+++ b/pyrene/src/components/TreeTable/TreeTableCell/TreeTableCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import TreeTablePropTypes from '../TreeTablePropTypes';
 
 import './treeTableCell.css';
@@ -12,7 +12,7 @@ export default class TreeTableCell extends React.PureComponent {
       <div style={this.props.style} styleName="treeTableCell">
 
         {this.props.firstColumn && (this.props.parent
-          ? <div styleName={classNames('pivotIcon', { sectionOpen: this.props.sectionOpen })} className="pyreneIcon-chevronDown" onClick={this.props.onExpandClick} />
+          ? <div styleName={clsx('pivotIcon', { sectionOpen: this.props.sectionOpen })} className="pyreneIcon-chevronDown" onClick={this.props.onExpandClick} />
           : <div styleName="iconSpaceholder" />
         )}
 

--- a/pyrene/src/components/TreeTable/TreeTableRow/TreeTableRow.jsx
+++ b/pyrene/src/components/TreeTable/TreeTableRow/TreeTableRow.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import clsx from 'clsx';
 
 import './treeTableRow.css';
 import TreeTableCell from '../TreeTableCell/TreeTableCell';
@@ -32,12 +32,12 @@ export default class TreeTableRow extends React.PureComponent {
     const hasDoubleClickAction = !hasSingleClickAction && this.props.onRowDoubleClick !== null;
     return (
       <div
-        styleName={classNames('treeTableRow', { activeAction: hasSingleClickAction || hasDoubleClickAction })}
+        styleName={clsx('treeTableRow', { activeAction: hasSingleClickAction || hasDoubleClickAction })}
       >
 
         {/* Row Elements are rendered here */}
         <div
-          styleName={classNames(
+          styleName={clsx(
             'rowElementsContainer',
             { openRootParent: this.props.level === 0 && this.props.isExpanded && this.props.parent },
             { highlighted: this.props.highlighted },


### PR DESCRIPTION
 Suggestion for replacing `classnames` by `clsx`.

@sanmiawi If this PR is accepted, you can continue working on the `styleName` by `className` [replacement](https://github.com/open-ch/pyrene/pull/9/files), after rebasing.


![Screenshot 2021-04-19 at 10 19 33](https://user-images.githubusercontent.com/6510794/115294156-85dd5100-a158-11eb-91db-fc5d71e47aba.png)
![Screenshot 2021-04-19 at 10 19 46](https://user-images.githubusercontent.com/6510794/115294230-a0172f00-a158-11eb-975f-ad2c32b2a40e.png)
