### PR TITLE
Remove text-transform from LabelAndValue component

### DIFF
--- a/pyrene/src/components/LabelAndValue/LabelAndValue.examples.tsx
+++ b/pyrene/src/components/LabelAndValue/LabelAndValue.examples.tsx
@@ -4,7 +4,7 @@ import { LabelAndValueProps } from './LabelAndValue';
 const LabelAndValue: Example<LabelAndValueProps> = {};
 
 LabelAndValue.props = {
-  label: 'bandwidth',
+  label: 'Bandwidth',
   value: '461.2 kb/s',
   size: 'small',
 };

--- a/pyrene/src/components/LabelAndValue/labelAndValue.css
+++ b/pyrene/src/components/LabelAndValue/labelAndValue.css
@@ -39,7 +39,6 @@
   height: 14px;
   color: var(--neutral-200);
   letter-spacing: 0.55px;
-  text-transform: capitalize;
   margin-bottom: 2px;
 }
 


### PR DESCRIPTION
Idea of this PR is to have the props capitalized in JS and not in CSS.