### PR TITLE
Remove text-transform from KeyValueTable component.

### DIFF
--- a/pyrene/src/components/KeyValueTable/KeyValueTable.examples.tsx
+++ b/pyrene/src/components/KeyValueTable/KeyValueTable.examples.tsx
@@ -3,7 +3,7 @@ import { Example } from '../../examples/Example';
 
 const examples: Example<KeyValueTableProps> = {
   props: {
-    title: 'KeyValue table',
+    title: 'KeyValue Table',
     rows: [
       { key: 'Key1', value: 'value1' },
       { key: 'Key2', value: 'value2' },

--- a/pyrene/src/components/KeyValueTable/keyValueTable.css
+++ b/pyrene/src/components/KeyValueTable/keyValueTable.css
@@ -57,5 +57,4 @@
   font-weight: 600;
   line-height: 1.5;
   color: var(--text);
-  text-transform: capitalize;
 }


### PR DESCRIPTION
Idea of this PR is to have the props capitalized in JS and not in CSS.