### PR TITLE
attempt getting rid date-fns-tz in prod build

### DIFF
--- a/pyrene/package-lock.json
+++ b/pyrene/package-lock.json
@@ -5863,7 +5863,8 @@
     "date-fns-tz": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.4.tgz",
-      "integrity": "sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g=="
+      "integrity": "sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.1",

--- a/pyrene/package.json
+++ b/pyrene/package.json
@@ -60,6 +60,7 @@
     "babel-plugin-typescript-to-proptypes": "^1.4.1",
     "copy-webpack-plugin": "^6.2.0",
     "css-loader": "^3.6.0",
+    "date-fns-tz": "^1.1.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "eslint": "^7.10.0",
@@ -98,7 +99,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "date-fns": "^2.16.1",
-    "date-fns-tz": "^1.1.4",
     "prop-types": "^15.6.1",
     "react-select": "^3.1.1",
     "react-table": "^6.8.6",

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -8,6 +8,7 @@ import ArrowSelector from './ArrowSelector/ArrowSelector';
 
 const convertTZ = (date, timeZone) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone }));
 
+// format date with such a pattern 'dd.MM.yyyy, HH:mm'
 // eslint-disable-next-line prefer-template
 const formatDate = (date) => ('0' + date.getDate()).slice(-2) + '.' + ('0' + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear() + ', ' + ('0' + date.getHours()).slice(-2) + ':' + ('0' + date.getMinutes()).slice(-2);
 

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -1,9 +1,7 @@
-// @ts-nocheck
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { differenceInMinutes, getTime, format } from 'date-fns';
-import { utcToZonedTime } from 'date-fns-tz';
+import { differenceInMinutes } from 'date-fns';
 
 
 import ArrowSelector from './ArrowSelector/ArrowSelector';
@@ -40,13 +38,6 @@ TimeRangeNavigationBar.renderCurrentTimeRange = (from, to, timezone) => {
   const formatedLocalTo0 = formatDate(localTo0);
 
   return `${formatedLocalForm0} - ${formatedLocalTo0}`;
-
-
-  const localFrom = getTime(utcToZonedTime(new Date(from), timezone));
-  const localTo = getTime(utcToZonedTime(new Date(to), timezone));
-  const pattern = 'dd.MM.yyyy, HH:mm';
-
-  return `${format(localFrom, pattern)} - ${format(localTo, pattern)}`;
 };
 
 TimeRangeNavigationBar.defaultProps = {

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -31,13 +31,13 @@ const TimeRangeNavigationBar = (props) => {
 };
 
 TimeRangeNavigationBar.renderCurrentTimeRange = (from, to, timezone) => {
-  const localFrom0 = convertTZ(new Date(from), timezone);
-  const formatedLocalForm0 = formatDate(localFrom0);
+  const localFrom = convertTZ(new Date(from), timezone);
+  const localFormFormatted = formatDate(localFrom);
 
-  const localTo0 = convertTZ(new Date(to), timezone);
-  const formatedLocalTo0 = formatDate(localTo0);
+  const localTo = convertTZ(new Date(to), timezone);
+  const localToFormatted = formatDate(localTo);
 
-  return `${formatedLocalForm0} - ${formatedLocalTo0}`;
+  return `${localFormFormatted} - ${localToFormatted}`;
 };
 
 TimeRangeNavigationBar.defaultProps = {

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -8,7 +8,8 @@ import ArrowSelector from './ArrowSelector/ArrowSelector';
 
 const convertTZ = (date, tzString) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone: tzString }));
 
-const formatDate = (date) => `${(`0${date.getDate()}`).slice(-2)}.${(`0${date.getMonth() + 1}`).slice(-2)}.${date.getFullYear()}, ${(`0${date.getHours()}`).slice(-2)}:${(`0${date.getMinutes()}`).slice(-2)}`;
+// eslint-disable-next-line prefer-template
+const formatDate = (date) => ('0' + date.getDate()).slice(-2) + '.' + ('0' + date.getMonth() + 1).slice(-2) + '.' + date.getFullYear() + ', ' + ('0' + date.getHours()).slice(-2) + ':' + ('0' + date.getMinutes()).slice(-2);
 
 const TimeRangeNavigationBar = (props) => {
   // We should not check for milliseconds but minutes changes

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -6,6 +7,10 @@ import { utcToZonedTime } from 'date-fns-tz';
 
 
 import ArrowSelector from './ArrowSelector/ArrowSelector';
+
+const convertTZ = (date, tzString) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone: tzString }));
+
+const formatDate = (date) => `${(`0${date.getDate()}`).slice(-2)}.${(`0${date.getMonth() + 1}`).slice(-2)}.${date.getFullYear()}, ${(`0${date.getHours()}`).slice(-2)}:${(`0${date.getMinutes()}`).slice(-2)}`;
 
 const TimeRangeNavigationBar = (props) => {
   // We should not check for milliseconds but minutes changes
@@ -28,6 +33,15 @@ const TimeRangeNavigationBar = (props) => {
 };
 
 TimeRangeNavigationBar.renderCurrentTimeRange = (from, to, timezone) => {
+  const localFrom0 = convertTZ(new Date(from), timezone);
+  const formatedLocalForm0 = formatDate(localFrom0);
+
+  const localTo0 = convertTZ(new Date(to), timezone);
+  const formatedLocalTo0 = formatDate(localTo0);
+
+  return `${formatedLocalForm0} - ${formatedLocalTo0}`;
+
+
   const localFrom = getTime(utcToZonedTime(new Date(from), timezone));
   const localTo = getTime(utcToZonedTime(new Date(to), timezone));
   const pattern = 'dd.MM.yyyy, HH:mm';

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -9,7 +9,7 @@ import ArrowSelector from './ArrowSelector/ArrowSelector';
 const convertTZ = (date, tzString) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone: tzString }));
 
 // eslint-disable-next-line prefer-template
-const formatDate = (date) => ('0' + date.getDate()).slice(-2) + '.' + ('0' + date.getMonth() + 1).slice(-2) + '.' + date.getFullYear() + ', ' + ('0' + date.getHours()).slice(-2) + ':' + ('0' + date.getMinutes()).slice(-2);
+const formatDate = (date) => ('0' + date.getDate()).slice(-2) + '.' + ('0' + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear() + ', ' + ('0' + date.getHours()).slice(-2) + ':' + ('0' + date.getMinutes()).slice(-2);
 
 const TimeRangeNavigationBar = (props) => {
   // We should not check for milliseconds but minutes changes

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/TimeRangeNavigationBar.jsx
@@ -6,7 +6,7 @@ import { differenceInMinutes } from 'date-fns';
 
 import ArrowSelector from './ArrowSelector/ArrowSelector';
 
-const convertTZ = (date, tzString) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone: tzString }));
+const convertTZ = (date, timeZone) => new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone }));
 
 // eslint-disable-next-line prefer-template
 const formatDate = (date) => ('0' + date.getDate()).slice(-2) + '.' + ('0' + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear() + ', ' + ('0' + date.getHours()).slice(-2) + ':' + ('0' + date.getMinutes()).slice(-2);
@@ -33,12 +33,12 @@ const TimeRangeNavigationBar = (props) => {
 
 TimeRangeNavigationBar.renderCurrentTimeRange = (from, to, timezone) => {
   const localFrom = convertTZ(new Date(from), timezone);
-  const localFormFormatted = formatDate(localFrom);
+  const localFromFormatted = formatDate(localFrom);
 
   const localTo = convertTZ(new Date(to), timezone);
   const localToFormatted = formatDate(localTo);
 
-  return `${localFormFormatted} - ${localToFormatted}`;
+  return `${localFromFormatted} - ${localToFormatted}`;
 };
 
 TimeRangeNavigationBar.defaultProps = {


### PR DESCRIPTION
Using @neonnoon [approach](https://github.com/open-ch/pyrene/pull/6/files) for converting a date with `time zone A` to date with `time zone B`, using **built-in JavaScript utility** was a better approach then import[ third-party lib](https://github.com/open-ch/pyrene/pull/19).