### PR TITLE
Remove text-transform from FilterTag component.

### DIFF
--- a/pyrene/src/components/Filter/FilterComponents/FilterTag.css
+++ b/pyrene/src/components/Filter/FilterComponents/FilterTag.css
@@ -25,7 +25,6 @@
   padding-right: 8px;
   padding-left: 8px;
   align-self: center;
-  text-transform: uppercase;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Idea of this PR is to have the props capitalized in JS and not in CSS.