### PR TITLE
Remove text-transform from TabView component.

### DIFF
--- a/pyrene/src/components/TabView/tabView.css
+++ b/pyrene/src/components/TabView/tabView.css
@@ -165,7 +165,6 @@
         line-height: 16px;
         letter-spacing: normal;
         color: var(--neutral-500);
-        text-transform: capitalize;
 
         &.disabled {
           opacity: .5;


### PR DESCRIPTION
Idea of this PR is to have the **props** capitalized in JS and not in CSS.