### PR TITLE
MC-21315: Remove text-transform from TableHeader component

### DIFF
--- a/pyrene/src/components/TreeTable/TreeTableHeader/treeTableHeader.css
+++ b/pyrene/src/components/TreeTable/TreeTableHeader/treeTableHeader.css
@@ -15,7 +15,6 @@
 
 .treeTableHeaderCell {
   box-sizing: border-box;
-  text-transform: capitalize;
   font-size: 12px;
   font-weight: 500;
   line-height: 18px;


### PR DESCRIPTION
Idea of this PR is to have the props capitalized in JS and not in CSS.