### PR TITLE
extended TabView to display extra section alongside tab name

### DIFF
--- a/pyrene/src/components/TabView/TabView.examples.jsx
+++ b/pyrene/src/components/TabView/TabView.examples.jsx
@@ -1,18 +1,27 @@
 import React from 'react';
+import Icon from '../Icon/Icon';
 import Placeholder from '../../examples/Placeholder';
 
 const TabView = {};
+
+const nameRenderCallback = (name) => (
+  <div style={{ marginLeft: 4 }}>
+    <Icon name={name} />
+  </div>
+);
 
 TabView.props = {
   initialTabName: 'Tab 1',
   directAccessTabs: 3,
   tabChanged: (stateProvider) => () => stateProvider.setState((prevState) => ({ tabName: prevState.tabName ? prevState.tabName + 1 : 1 })),
   tabs: (stateProvider) => [
-    { name: 'Tab 1', renderCallback: () => <Placeholder label="tab 1" />, disabled: false }, // eslint-disable-line react/display-name
+    { name: 'Tab 1', nameRenderCallback: () => nameRenderCallback('home'), renderCallback: () => <Placeholder label="tab 1" /> }, // eslint-disable-line react/display-name
     { name: 'Tab 2', renderCallback: () => <Placeholder label={`Tab ${stateProvider.state.tabName}`} />, disabled: false }, // eslint-disable-line react/display-name
     { name: 'Tab 3', renderCallback: () => <Placeholder label="tab 3" />, disabled: true }, // eslint-disable-line react/display-name
     { name: 'Looooooooooooooooooooooooooooooooooooooong Name', renderCallback: () => <Placeholder label="tab 4" /> }, // eslint-disable-line react/display-name
-    { name: 'Tab 5', renderCallback: () => <Placeholder label="tab 5" />, disabled: true }, // eslint-disable-line react/display-name
+    {
+      name: 'Tab 5', nameRenderCallback: () => nameRenderCallback('info'), renderCallback: () => <Placeholder label="tab 5" />, disabled: true, // eslint-disable-line react/display-name
+    },
   ],
 };
 

--- a/pyrene/src/components/TabView/TabView.examples.jsx
+++ b/pyrene/src/components/TabView/TabView.examples.jsx
@@ -4,7 +4,7 @@ import Placeholder from '../../examples/Placeholder';
 
 const TabView = {};
 
-const nameRenderCallback = (name) => (
+const renderAuxiliaryIcon = (name) => (
   <div style={{ marginLeft: 4 }}>
     <Icon name={name} />
   </div>
@@ -15,12 +15,12 @@ TabView.props = {
   directAccessTabs: 3,
   tabChanged: (stateProvider) => () => stateProvider.setState((prevState) => ({ tabName: prevState.tabName ? prevState.tabName + 1 : 1 })),
   tabs: (stateProvider) => [
-    { name: 'Tab 1', nameRenderCallback: () => nameRenderCallback('home'), renderCallback: () => <Placeholder label="tab 1" /> }, // eslint-disable-line react/display-name
+    { name: 'Tab 1', renderAuxiliaryInfo: () => renderAuxiliaryIcon('home'), renderCallback: () => <Placeholder label="tab 1" /> }, // eslint-disable-line react/display-name
     { name: 'Tab 2', renderCallback: () => <Placeholder label={`Tab ${stateProvider.state.tabName}`} />, disabled: false }, // eslint-disable-line react/display-name
     { name: 'Tab 3', renderCallback: () => <Placeholder label="tab 3" />, disabled: true }, // eslint-disable-line react/display-name
     { name: 'Looooooooooooooooooooooooooooooooooooooong Name', renderCallback: () => <Placeholder label="tab 4" /> }, // eslint-disable-line react/display-name
     {
-      name: 'Tab 5', nameRenderCallback: () => nameRenderCallback('info'), renderCallback: () => <Placeholder label="tab 5" />, disabled: true, // eslint-disable-line react/display-name
+      name: 'Tab 5', renderAuxiliaryInfo: () => renderAuxiliaryIcon('info'), renderCallback: () => <Placeholder label="tab 5" />, disabled: true, // eslint-disable-line react/display-name
     },
   ],
 };

--- a/pyrene/src/components/TabView/TabView.jsx
+++ b/pyrene/src/components/TabView/TabView.jsx
@@ -86,6 +86,7 @@ export default class TabView extends React.Component {
           role="option"
         >
           <span styleName="optionLabel">{tab.name}</span>
+          {tab.nameRenderCallback && tab.nameRenderCallback()}
         </div>
       ))}
     </div>
@@ -112,6 +113,7 @@ export default class TabView extends React.Component {
                 role="tab"
               >
                 {tab.name}
+                {tab.nameRenderCallback && tab.nameRenderCallback()}
               </div>
             ))
           }
@@ -189,11 +191,13 @@ TabView.propTypes = {
    */
   tabHeaderElement: PropTypes.element,
   /**
-   * Data input array for the tabs. Type: [{ name: string (required), renderCallback: func (required), disabled: bool }]
+   * Data input array for the tabs.
+   * Type: [{ name: string (required), nameRenderCallback: func, renderCallback: func (required), disabled: bool }]
    */
   tabs: PropTypes.arrayOf(PropTypes.shape({
     disabled: PropTypes.bool,
     name: PropTypes.string.isRequired,
+    nameRenderCallback: PropTypes.func,
     renderCallback: PropTypes.func.isRequired,
   })).isRequired,
 };

--- a/pyrene/src/components/TabView/TabView.jsx
+++ b/pyrene/src/components/TabView/TabView.jsx
@@ -86,7 +86,7 @@ export default class TabView extends React.Component {
           role="option"
         >
           <span styleName="optionLabel">{tab.name}</span>
-          {tab.nameRenderCallback && tab.nameRenderCallback()}
+          {tab.renderAuxiliaryInfo?.()}
         </div>
       ))}
     </div>
@@ -113,7 +113,7 @@ export default class TabView extends React.Component {
                 role="tab"
               >
                 {tab.name}
-                {tab.nameRenderCallback && tab.nameRenderCallback()}
+                {tab.renderAuxiliaryInfo?.()}
               </div>
             ))
           }
@@ -192,12 +192,12 @@ TabView.propTypes = {
   tabHeaderElement: PropTypes.element,
   /**
    * Data input array for the tabs.
-   * Type: [{ name: string (required), nameRenderCallback: func, renderCallback: func (required), disabled: bool }]
+   * Type: [{ name: string (required), renderAuxiliaryInfo: func, renderCallback: func (required), disabled: bool }]
    */
   tabs: PropTypes.arrayOf(PropTypes.shape({
     disabled: PropTypes.bool,
     name: PropTypes.string.isRequired,
-    nameRenderCallback: PropTypes.func,
+    renderAuxiliaryInfo: PropTypes.func,
     renderCallback: PropTypes.func.isRequired,
   })).isRequired,
 };

--- a/pyrene/src/components/TabView/TabView.spec.jsx
+++ b/pyrene/src/components/TabView/TabView.spec.jsx
@@ -8,7 +8,7 @@ const props = {
   tabs: [
     {
       name: 'Tab 1',
-      nameRenderCallback: () => <div className="nameCallback" />, // eslint-disable-line react/display-name
+      renderAuxiliaryInfo: () => <div className="auxiliaryInfo" />, // eslint-disable-line react/display-name
       renderCallback: () => <div>Tab1Content</div>, // eslint-disable-line react/display-name
       disabled: false,
     },
@@ -30,10 +30,10 @@ describe('<TabView />', () => {
     expect(rendered.contains('Tab2Content')).toBe(true);
   });
 
-  it('displays the name with custom render callback', () => {
+  it('displays the name with auxiliary info callback', () => {
     const rendered = shallow(<TabView {...props} />);
-    expect(rendered.find('.tabBar').childAt(0).find('.nameCallback')).toHaveLength(1);
-    expect(rendered.find('.tabBar').childAt(1).find('.nameCallback')).toHaveLength(0);
+    expect(rendered.find('.tabBar').childAt(0).find('.auxiliaryInfo')).toHaveLength(1);
+    expect(rendered.find('.tabBar').childAt(1).find('.auxiliaryInfo')).toHaveLength(0);
   });
 
   it('has clickable tabs', () => {

--- a/pyrene/src/components/TabView/TabView.spec.jsx
+++ b/pyrene/src/components/TabView/TabView.spec.jsx
@@ -8,6 +8,7 @@ const props = {
   tabs: [
     {
       name: 'Tab 1',
+      nameRenderCallback: () => <div className="nameCallback" />, // eslint-disable-line react/display-name
       renderCallback: () => <div>Tab1Content</div>, // eslint-disable-line react/display-name
       disabled: false,
     },
@@ -29,6 +30,11 @@ describe('<TabView />', () => {
     expect(rendered.contains('Tab2Content')).toBe(true);
   });
 
+  it('displays the name with custom render callback', () => {
+    const rendered = shallow(<TabView {...props} />);
+    expect(rendered.find('.tabBar').childAt(0).find('.nameCallback')).toHaveLength(1);
+    expect(rendered.find('.tabBar').childAt(1).find('.nameCallback')).toHaveLength(0);
+  });
 
   it('has clickable tabs', () => {
     const rendered = mount(<TabView {...props} />);

--- a/pyrene/src/components/TabView/tabView.css
+++ b/pyrene/src/components/TabView/tabView.css
@@ -25,6 +25,7 @@
 
   & .tab {
     box-sizing: border-box;
+    display: flex;
     margin-right: 24px;
 
     line-height: 16px;


### PR DESCRIPTION
This PR is to extend the existing TabView component such that on the right side of tab name, some additional information could be displayed.

Visual effect:
![Screenshot 2021-04-26 at 17 11 52](https://user-images.githubusercontent.com/10343396/116112918-524e7980-a6b8-11eb-9550-b461290712b5.png)
![Screenshot 2021-04-26 at 17 11 56](https://user-images.githubusercontent.com/10343396/116112933-55e20080-a6b8-11eb-9320-8def9404fe4b.png)

I originally thought of an alternative approach, which is to make the current `name` prop and `nameRenderCallback` props mutually exclusive - if there is `name`, display the name; otherwise display the customizedly rendered name.

However, after many considerations I switched to the current approach where `name` is displayed no matter what and the additional section on the right side `nameRenderCallback` is optionally rendered.

The reasons are:
- it's backward compatible
- `name` is kinda used as `key` for this component, without the `name` prop we still would need to have something like `key` in its place
- it helps make the CSS more consistent when toggling the tabs; otherwise when using this component, the customized name would have to also care about its different look when it is in selected/unselected state