### PR TITLE
Don't use npm ci for kitchensink.

### DIFF
--- a/kitchensink/package.json
+++ b/kitchensink/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf dist node_modules",
-    "prebuild": "npm ci",
+    "prebuild": "npm install",
     "build": "webpack",
     "watch": "webpack-dev-server",
     "watchSourceMap": "SOURCE_MAP=true npm run watch",


### PR DESCRIPTION
Reverts part of `npm ci` introduced by e9d2048bf1d7844323c8fc25b232dbca502f52bf. The reason to introduce `npm ci` was exactly to make sure the build fails in case `package.json`/`package-lock.json` changes.

What I have completely forgot about was that we change kitchensink's `package.json` on purpose on pyrene/pyrene-graphs releases. So `npm ci` is not appropriate here.

https://docs.npmjs.com/cli/v7/commands/npm-ci