### PR TITLE
Added toggleColumnsCallback to TreeTable

### DIFF
--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -176,7 +176,7 @@ class TreeTable extends React.Component {
 
     const isColumnHidden = (hidden) => typeof hidden === 'undefined' || hidden !== true;
 
-    const toggleColumnDisplay = (columnId, hiddenValue, callback) => {
+    const toggleColumnDisplay = (columnId, hiddenValue, handler) => {
       const updatedColumns = columns.map((col) => {
         if (col.id === columnId) {
           return { ...col, hidden: hiddenValue };
@@ -184,11 +184,11 @@ class TreeTable extends React.Component {
         return col;
       });
 
-      this.setState({ columns: updatedColumns }, () => callback?.(updatedColumns));
+      this.setState({ columns: updatedColumns }, () => handler?.(updatedColumns));
     };
 
-    const restoreColumnDefaults = (callback) => {
-      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) }, () => callback?.(props.columns));
+    const restoreColumnDefaults = (handler) => {
+      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) }, () => handler?.(props.columns));
     };
 
     const renderLoader = () => (
@@ -204,8 +204,8 @@ class TreeTable extends React.Component {
 
     const getActionBar = () => {
       const listItems = columns.slice(1).map((col) => ({ id: col.id, label: col.headerName, value: isColumnHidden(col.hidden) }));
-      const onItemClick = (columnId, hiddenValue) => toggleColumnDisplay(columnId, hiddenValue, props.toggleColumnsCallback);
-      const onRestoreDefault = () => restoreColumnDefaults(props.toggleColumnsCallback);
+      const onItemClick = (columnId, hiddenValue) => toggleColumnDisplay(columnId, hiddenValue, props.toggleColumnsHandler);
+      const onRestoreDefault = () => restoreColumnDefaults(props.toggleColumnsHandler);
       const toggleColumns = props.toggleColumns;
 
       const columnToggleProps = {
@@ -325,7 +325,7 @@ TreeTable.defaultProps = {
   virtualized: false,
   onFilterChange: () => null,
   setUniqueRowKey: () => null,
-  toggleColumnsCallback: () => null,
+  toggleColumnsHandler: () => null,
   onRowHover: null,
 };
 
@@ -415,9 +415,9 @@ TreeTable.propTypes = {
    */
   toggleColumns: PropTypes.bool,
   /**
-   * Callback function when the columns of the table are getting toggled.
+   * Callback handler function when the columns of the table are getting toggled.
    */
-  toggleColumnsCallback: PropTypes.func,
+  toggleColumnsHandler: PropTypes.func,
   /**
    * Whether the table should be virtualized (only visible rows rendered - faster) or all rows always rendered. The height prop must also be provided if virtualized is true.
    */

--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -54,7 +54,7 @@ class TreeTable extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {;
+  componentDidUpdate(prevProps) {
     if (this.props.data !== prevProps.data) {
       const rows = TreeTableUtils.initialiseRootData(this.props.data, this.props.setUniqueRowKey);
       // eslint-disable-next-line react/no-did-update-set-state

--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -187,8 +187,8 @@ class TreeTable extends React.Component {
       this.setState({ columns: updatedColumns }, callback?.(updatedColumns));
     };
 
-    const restoreColumnDefaults = () => {
-      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) });
+    const restoreColumnDefaults = (callback) => {
+      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) }, callback?.(props.columns));
     };
 
     const renderLoader = () => (
@@ -205,7 +205,7 @@ class TreeTable extends React.Component {
     const getActionBar = () => {
       const listItems = columns.slice(1).map((col) => ({ id: col.id, label: col.headerName, value: isColumnHidden(col.hidden) }));
       const onItemClick = (columnId, hiddenValue) => toggleColumnDisplay(columnId, hiddenValue, props.toggleColumnsCallback);
-      const onRestoreDefault = restoreColumnDefaults;
+      const onRestoreDefault = () => restoreColumnDefaults(props.toggleColumnsCallback);
       const toggleColumns = props.toggleColumns;
 
       const columnToggleProps = {

--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -54,7 +54,7 @@ class TreeTable extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps) {;
     if (this.props.data !== prevProps.data) {
       const rows = TreeTableUtils.initialiseRootData(this.props.data, this.props.setUniqueRowKey);
       // eslint-disable-next-line react/no-did-update-set-state
@@ -184,11 +184,11 @@ class TreeTable extends React.Component {
         return col;
       });
 
-      this.setState({ columns: updatedColumns }, callback?.(updatedColumns));
+      this.setState({ columns: updatedColumns }, () => callback?.(updatedColumns));
     };
 
     const restoreColumnDefaults = (callback) => {
-      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) }, callback?.(props.columns));
+      this.setState({ columns: TreeTableUtils.prepareColumnToggle(props.columns) }, () => callback?.(props.columns));
     };
 
     const renderLoader = () => (

--- a/pyrene/src/components/TreeTable/TreeTable.jsx
+++ b/pyrene/src/components/TreeTable/TreeTable.jsx
@@ -176,7 +176,7 @@ class TreeTable extends React.Component {
 
     const isColumnHidden = (hidden) => typeof hidden === 'undefined' || hidden !== true;
 
-    const toggleColumnDisplay = (columnId, hiddenValue) => {
+    const toggleColumnDisplay = (columnId, hiddenValue, callback) => {
       const updatedColumns = columns.map((col) => {
         if (col.id === columnId) {
           return { ...col, hidden: hiddenValue };
@@ -184,7 +184,7 @@ class TreeTable extends React.Component {
         return col;
       });
 
-      this.setState({ columns: updatedColumns });
+      this.setState({ columns: updatedColumns }, callback?.(updatedColumns));
     };
 
     const restoreColumnDefaults = () => {
@@ -204,7 +204,7 @@ class TreeTable extends React.Component {
 
     const getActionBar = () => {
       const listItems = columns.slice(1).map((col) => ({ id: col.id, label: col.headerName, value: isColumnHidden(col.hidden) }));
-      const onItemClick = toggleColumnDisplay;
+      const onItemClick = (columnId, hiddenValue) => toggleColumnDisplay(columnId, hiddenValue, props.toggleColumnsCallback);
       const onRestoreDefault = restoreColumnDefaults;
       const toggleColumns = props.toggleColumns;
 
@@ -325,6 +325,7 @@ TreeTable.defaultProps = {
   virtualized: false,
   onFilterChange: () => null,
   setUniqueRowKey: () => null,
+  toggleColumnsCallback: () => null,
   onRowHover: null,
 };
 
@@ -413,6 +414,10 @@ TreeTable.propTypes = {
    * Whether the columns (hide/show) popover is available to the user.
    */
   toggleColumns: PropTypes.bool,
+  /**
+   * Callback function when the columns of the table are getting toggled.
+   */
+  toggleColumnsCallback: PropTypes.func,
   /**
    * Whether the table should be virtualized (only visible rows rendered - faster) or all rows always rendered. The height prop must also be provided if virtualized is true.
    */


### PR DESCRIPTION
Thanks a lot for having a look at this PR!

The purpose of this PR is to expose a callback function when the columns are toggled for visibility such that the `columns` state could be used by the parent page.

Example use case: when there are multiple tables in different tabs (with TabView), switching to a different tab and then switching back to the original tab would reset all the selected columns in the table, so that user has to select the columns again, which can be quite much effort.

If you find this approach acceptable, I'm wondering maybe it's best that I extend the Table component similarly, so that the behaviors between tables are consistent?

Please let me know what you think :) Thanks a lot!