### PR TITLE
development documentation

### DIFF
--- a/pyrene/DEVELOPMENT.md
+++ b/pyrene/DEVELOPMENT.md
@@ -11,7 +11,7 @@ Kitchensink uses propTypes and typescript types to generate the documentation.
 #### Functional typescript components
 When using functional components in typescript, make sure to explicitely set the type of the props:
 ```
-interface MyComponentProps {
+export interface MyComponentProps {
    name: string
 }
 const MyComponent: React.FC<MyComponentProps>({name = 'John'}: MyComponentProps)


### PR DESCRIPTION
The **Type** of the API of Pyerene component has to be exported.

If you do not export it, the linter complains. See example with `<TextAreaProps />`.

![Screenshot 2021-05-21 at 08 45 22](https://user-images.githubusercontent.com/6510794/119094251-15547900-ba11-11eb-8dc5-799e75d7c7df.png)
