### PR TITLE
Modal component can be closed in Kitchensink

### DIFF
--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -104,7 +104,11 @@ export default class ComponentEditor extends React.Component {
             <div className={styles.componentDisplay}>
               {
               // this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={(action)=>displayedComponent} /> : displayedComponent
-              this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={(onClick)=> <button onClick={onClick}>click on me !</button>} /> : displayedComponent
+              this.props.examples.trigger ?
+                <ParentButton
+                  onClick={this.props.examples.onClick}
+                  component={(onClick)=> <div> <div>This is a modal component</div><div><button onClick={onClick}>cancel</button></div></div>}
+                /> : displayedComponent
             }
             </div>
             <CodeBlock

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -105,9 +105,8 @@ export default class ComponentEditor extends React.Component {
               {
               this.props.examples.trigger ?
                 <ParentButton
-                  componentMeta={Component}
-                  onClick={this.props.examples.onClick}
-                  component={(onClose)=> <Component {...mergedComponentProps} onClose={onClose} />}
+                  component={displayedComponent}
+                  render={(ComponentToRender, onClose)=> React.cloneElement(ComponentToRender, { onClose })}
                 /> : displayedComponent
             }
             </div>

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -103,12 +103,14 @@ export default class ComponentEditor extends React.Component {
             <div className={clsx(styles.sun, { [styles.darkMode]: darkMode })} onClick={() => this.handleSunClick()} />
             <div className={styles.componentDisplay}>
               {
-              this.props.examples.trigger ?
-                <ParentButton
-                  component={displayedComponent}
-                  render={(ComponentToRender, onClose)=> React.cloneElement(ComponentToRender, { onClose })}
-                /> : displayedComponent
-            }
+                this.props.examples.trigger
+                  ? (
+                    <ParentButton
+                      component={displayedComponent}
+                      render={(ComponentToRender, onClose) => React.cloneElement(ComponentToRender, { onClose })}
+                    />
+                  ) : displayedComponent
+              }
             </div>
             <CodeBlock
               component={displayedComponent}

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -103,11 +103,11 @@ export default class ComponentEditor extends React.Component {
             <div className={clsx(styles.sun, { [styles.darkMode]: darkMode })} onClick={() => this.handleSunClick()} />
             <div className={styles.componentDisplay}>
               {
-              // this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={(action)=>displayedComponent} /> : displayedComponent
               this.props.examples.trigger ?
                 <ParentButton
+                  componentMeta={Component}
                   onClick={this.props.examples.onClick}
-                  component={(onClick)=> <div> <div>This is a modal component</div><div><button onClick={onClick}>cancel</button></div></div>}
+                  component={(onClose)=> <Component {...mergedComponentProps} onClose={onClose} />}
                 /> : displayedComponent
             }
             </div>

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -137,8 +137,8 @@ ComponentEditor.propTypes = {
     examples: PropTypes.arrayOf(
       PropTypes.shape(),
     ),
-    props: PropTypes.shape(),
     onClick: PropTypes.func,
+    props: PropTypes.shape(),
     trigger: PropTypes.bool,
   }).isRequired,
 };

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -102,7 +102,10 @@ export default class ComponentEditor extends React.Component {
             <div className={clsx(styles.pin, { [styles.pinned]: pinned })} onClick={() => this.handlePinClick()} />
             <div className={clsx(styles.sun, { [styles.darkMode]: darkMode })} onClick={() => this.handleSunClick()} />
             <div className={styles.componentDisplay}>
-              {this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={displayedComponent} /> : displayedComponent}
+              {
+              // this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={(action)=>displayedComponent} /> : displayedComponent
+              this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={(onClick)=> <button onClick={onClick}>click on me !</button>} /> : displayedComponent
+            }
             </div>
             <CodeBlock
               component={displayedComponent}
@@ -137,7 +140,6 @@ ComponentEditor.propTypes = {
     examples: PropTypes.arrayOf(
       PropTypes.shape(),
     ),
-    onClick: PropTypes.func,
     props: PropTypes.shape(),
     trigger: PropTypes.bool,
   }).isRequired,

--- a/kitchensink/src/app/common/ComponentEditor.jsx
+++ b/kitchensink/src/app/common/ComponentEditor.jsx
@@ -102,7 +102,7 @@ export default class ComponentEditor extends React.Component {
             <div className={clsx(styles.pin, { [styles.pinned]: pinned })} onClick={() => this.handlePinClick()} />
             <div className={clsx(styles.sun, { [styles.darkMode]: darkMode })} onClick={() => this.handleSunClick()} />
             <div className={styles.componentDisplay}>
-              {this.props.examples.trigger ? <ParentButton component={displayedComponent} /> : displayedComponent}
+              {this.props.examples.trigger ? <ParentButton onClick={this.props.examples.onClick} component={displayedComponent} /> : displayedComponent}
             </div>
             <CodeBlock
               component={displayedComponent}
@@ -138,6 +138,7 @@ ComponentEditor.propTypes = {
       PropTypes.shape(),
     ),
     props: PropTypes.shape(),
+    onClick: PropTypes.func,
     trigger: PropTypes.bool,
   }).isRequired,
 };

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -20,7 +20,7 @@ export default class ParentButton extends React.Component {
   };
 
   handleClick = () => {
-    this.onClick?.();
+    this.props.onClick?.();
     this.toggleComponent();
   };
 

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -24,18 +24,17 @@ export default class ParentButton extends React.Component {
   };
 
   render() {
-    console.log('this.props', this.props);
     return (
       <div>
         <Button
-          label={`Trigger ${this.props.component?.type?.displayName || ''}`}
+          label={`Trigger ${this.props.component.type.displayName}`}
           type="primary"
           onClick={this.handleClick}
         />
         { // check if children is render props or not
-          typeof this.props.component !== 'function' ?
-            this.state.displayComponent && this.props.component :
-            this.state.displayComponent && this.props.component(this.handleClick)
+          typeof this.props.render === 'function' ?
+            this.state.displayComponent && this.props.render(this.props.component, this.handleClick) :
+            this.state.displayComponent && this.props.component
         }
       </div>
     );
@@ -48,9 +47,6 @@ ParentButton.displayName = 'ParentButton';
 ParentButton.defaultProps = {};
 
 ParentButton.propTypes = {
-  componentMeta:PropTypes.element,
-  component: PropTypes.oneOfType([
-      PropTypes.element,
-      PropTypes.func,
-    ]).isRequired
+  component: PropTypes.element.isRequired,
+  render: PropTypes.func,
 };

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -47,7 +47,6 @@ ParentButton.displayName = 'ParentButton';
 ParentButton.defaultProps = {};
 
 ParentButton.propTypes = {
-  onClick: PropTypes.func,
   component: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -20,7 +20,9 @@ export default class ParentButton extends React.Component {
   };
 
   handleClick = () => {
-    this.props.onClick?.();
+    if(this.props.onClick){
+      this.props.onClick();
+    }
     this.toggleComponent();
   };
 

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -24,10 +24,11 @@ export default class ParentButton extends React.Component {
   };
 
   render() {
+    console.log('this.props', this.props);
     return (
       <div>
         <Button
-         // label={`Trigger ${this.props.component.type.displayName}`}
+          label={`Trigger ${this.props.component?.type?.displayName || ''}`}
           type="primary"
           onClick={this.handleClick}
         />
@@ -47,6 +48,7 @@ ParentButton.displayName = 'ParentButton';
 ParentButton.defaultProps = {};
 
 ParentButton.propTypes = {
+  componentMeta:PropTypes.element,
   component: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -32,11 +32,10 @@ export default class ParentButton extends React.Component {
           type="primary"
           onClick={this.handleClick}
         />
-        {
-        // this.state.displayComponent && this.props.component
-        }
-        {
-          this.props.component(this.handleClick)
+        { // check if children is render props or not
+          typeof this.props.component !== 'function' ?
+            this.state.displayComponent && this.props.component :
+            this.state.displayComponent && this.props.component(this.handleClick)
         }
       </div>
     );

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -20,6 +20,7 @@ export default class ParentButton extends React.Component {
   };
 
   handleClick = () => {
+    this.onClick?.();
     this.toggleComponent();
   };
 
@@ -43,5 +44,6 @@ ParentButton.displayName = 'ParentButton';
 ParentButton.defaultProps = {};
 
 ParentButton.propTypes = {
+  onClick: PropTypes.func,
   component: PropTypes.element.isRequired,
 };

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -20,7 +20,6 @@ export default class ParentButton extends React.Component {
   };
 
   handleClick = () => {
-    console.log('displayComponent', this.state.displayComponent);
     this.toggleComponent();
   };
 
@@ -49,5 +48,8 @@ ParentButton.defaultProps = {};
 
 ParentButton.propTypes = {
   onClick: PropTypes.func,
-  component: PropTypes.element.isRequired,
+  component: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+    ]).isRequired
 };

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -32,9 +32,9 @@ export default class ParentButton extends React.Component {
           onClick={this.handleClick}
         />
         { // check if children is render props or not
-          typeof this.props.render === 'function' ?
-            this.state.displayComponent && this.props.render(this.props.component, this.handleClick) :
-            this.state.displayComponent && this.props.component
+          typeof this.props.render === 'function'
+            ? this.state.displayComponent && this.props.render(this.props.component, this.handleClick)
+            : this.state.displayComponent && this.props.component
         }
       </div>
     );
@@ -44,7 +44,9 @@ export default class ParentButton extends React.Component {
 
 ParentButton.displayName = 'ParentButton';
 
-ParentButton.defaultProps = {};
+ParentButton.defaultProps = {
+  render: undefined,
+};
 
 ParentButton.propTypes = {
   component: PropTypes.element.isRequired,

--- a/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
+++ b/kitchensink/src/app/common/PageElements/ParentButton/ParentButton.jsx
@@ -20,9 +20,7 @@ export default class ParentButton extends React.Component {
   };
 
   handleClick = () => {
-    if(this.props.onClick){
-      this.props.onClick();
-    }
+    console.log('displayComponent', this.state.displayComponent);
     this.toggleComponent();
   };
 
@@ -30,11 +28,16 @@ export default class ParentButton extends React.Component {
     return (
       <div>
         <Button
-          label={`Trigger ${this.props.component.type.displayName}`}
+         // label={`Trigger ${this.props.component.type.displayName}`}
           type="primary"
           onClick={this.handleClick}
         />
-        {this.state.displayComponent && this.props.component}
+        {
+        // this.state.displayComponent && this.props.component
+        }
+        {
+          this.props.component(this.handleClick)
+        }
       </div>
     );
   }

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -16,7 +16,7 @@ const Modal = {
       { type: 'ghost', label: 'Disabled', action: (): void => {} },
     ],
     rightButtonBarElements: [
-      { type: 'secondary', label: 'Cancel', action: (): void => {} },
+      { type: 'secondary', label: 'Cancel', action: () => console.log('thomas') },
       { type: 'primary', label: 'Apply', action: (): void => {} },
     ],
     defaultExpanded: true,
@@ -24,7 +24,6 @@ const Modal = {
     renderHeader: false,
   },
   trigger: true,
-  onClick: () => console.log('thomas'),
   category: '',
 };
 

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -7,7 +7,7 @@ function alertClickedButton(buttonLabel:string):void { alert(`${buttonLabel} but
 const Modal = {
   props: {
     renderCallback: function displayPlaceHolder(): React.ReactElement {
-      return (<Placeholder label="Hit ESC to close the Modal" width={392} />);
+      return (<Placeholder label="Content" width={392} />);
     },
     canNext: true,
     canPrevious: true,

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -3,7 +3,9 @@ import Placeholder from '../../examples/Placeholder';
 
 const Modal = {
   props: {
-    renderCallback: () => <Placeholder label="Hit ESC to close the Modal" width={392} />,
+    renderCallback: function displayPlaceHolder(): React.ReactElement {
+      return (<Placeholder label="Hit ESC to close the Modal" width={392} />);
+    },
     canNext: true,
     canPrevious: true,
     displayNavigationArrows: true,

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import Placeholder from '../../examples/Placeholder';
 
+// eslint-disable-next-line no-alert
+function alertClickedButton(buttonLabel:string):void { alert(`${buttonLabel} button clicked`); }
+
 const Modal = {
   props: {
     renderCallback: function displayPlaceHolder(): React.ReactElement {
@@ -12,16 +15,16 @@ const Modal = {
     size: 'small',
     title: 'Modal',
     leftButtonBarElements: [
-      { type: 'danger', label: 'Delete', action: ():void => {} },
-      { type: 'ghost', label: 'Disabled', action: (): void => {} },
+      { type: 'danger', label: 'Delete', action: ():void => alertClickedButton('Delete') },
+      { type: 'ghost', label: 'Disabled', action: ():void => alertClickedButton('Disabled') },
     ],
     rightButtonBarElements: [
-      { type: 'secondary', label: 'Cancel', action: (): void => {} },
-      { type: 'primary', label: 'Apply', action: (): void => {} },
+      { type: 'secondary', label: 'Cancel', action: ():void => alertClickedButton('Cancel') },
+      { type: 'primary', label: 'Apply', action: ():void => alertClickedButton('Apply') },
     ],
     defaultExpanded: true,
     renderFooter: true,
-    renderHeader: false,
+    renderHeader: true,
   },
   trigger: true,
   category: '',

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -3,9 +3,7 @@ import Placeholder from '../../examples/Placeholder';
 
 const Modal = {
   props: {
-    renderCallback: function displayPlaceHolder(): React.ReactElement {
-      return (<Placeholder label="Content" width={392} />);
-    },
+    renderCallback: () => <Placeholder label="Hit ESC to close the Modal" width={392} />,
     canNext: true,
     canPrevious: true,
     displayNavigationArrows: true,

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -24,6 +24,7 @@ const Modal = {
     renderHeader: false,
   },
   trigger: true,
+  onClick: () => console.log('thomas'),
   category: '',
 };
 

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -16,7 +16,7 @@ const Modal = {
       { type: 'ghost', label: 'Disabled', action: (): void => {} },
     ],
     rightButtonBarElements: [
-      { type: 'secondary', label: 'Cancel', action: () => console.log('thomas') },
+      { type: 'secondary', label: 'Cancel', action: (): void => {} },
       { type: 'primary', label: 'Apply', action: (): void => {} },
     ],
     defaultExpanded: true,


### PR DESCRIPTION
## Goal of the present PR
In kitchensink while testing the component called [Modal](https://open-ch.github.io/pyrene/Layout/Modal), there is no way to **close** it after that component has rendered.

## Follow-up
The present PR is an alternative to the [PR-120](https://github.com/open-ch/pyrene/pull/120).

## Remark
The present PR implements a React pattern called [Render props](https://reactjs.org/docs/render-props.html).

## Test
Go to `Modal` component in Kitchensink, do trigger the component rendering and hit the key **escape** or click the **close button**.

## Illustration

![Screen Recording 2021-05-31 at 07 13 55](https://user-images.githubusercontent.com/6510794/120143881-438c4280-c1e1-11eb-991e-8d703e6baec3.gif)
