### PR TITLE
Update eslint parser to new package

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -98,7 +98,7 @@ module.exports = {
     "mount": "true",
   },
 
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
 
   "parserOptions": {
     "ecmaFeatures": {

--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": ">=4.2.0",
     "@typescript-eslint/parser": ">=4.2.0",
-    "babel-eslint": ">=10.0.0",
+    "@babel/eslint-parser": ">=7",
     "eslint": ">=6.5.1",
     "eslint-config-airbnb": ">=18.0.1",
     "eslint-config-airbnb-typescript": ">=11.0.0",


### PR DESCRIPTION
babel-eslint is deprecated. 