### PR TITLE
Add Focus Style to Dropdown Button

### DIFF
--- a/pyrene/src/components/DropdownButton/dropdownButton.css
+++ b/pyrene/src/components/DropdownButton/dropdownButton.css
@@ -35,7 +35,7 @@
   outline: 0;
 }
 
-.button:hover,
+.button:hover, .button:focus,
 .openedDropdown {
   background-color: var(--secondary);
 }


### PR DESCRIPTION
Nothing visible to show that the element is active (if selected with the tab button)
![Screenshot 2021-06-01 at 13 26 53](https://user-images.githubusercontent.com/12200093/120316465-c1ce0f00-c2dd-11eb-84ee-8a00551ee9a5.png)

Using the :hover styling for the :focus so that component is highlighted once it receives focus from mouse hover or tab button
![Screenshot 2021-06-01 at 13 27 13](https://user-images.githubusercontent.com/12200093/120316680-f772f800-c2dd-11eb-83ef-17d2f288ca4c.png)

