### PR TITLE
Improve multi value labels

### DIFF
--- a/pyrene/src/components/MultiSelect/MultiSelect.jsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.jsx
@@ -197,7 +197,7 @@ MultiSelect.defaultProps = {
   helperLabel: '',
   invalidLabel: '',
   title: '',
-  maxValueLabelWidth: 123,
+  maxValueLabelWidth: '123px',
   name: '',
   defaultValue: [],
   options: [],
@@ -261,7 +261,7 @@ MultiSelect.propTypes = {
   /**
    * Maximum width of the value label in pixels. Use false to disable a maximum width.
    */
-  maxValueLabelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([false])]), // eslint-disable-line react/no-unused-prop-types
+  maxValueLabelWidth: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
   /**
    * Sets the html name property of the form element.
    */

--- a/pyrene/src/components/MultiSelect/MultiSelect.jsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.jsx
@@ -189,6 +189,7 @@ MultiSelect.defaultProps = {
   helperLabel: '',
   invalidLabel: '',
   title: '',
+  maxValueLabelWidth: 123,
   name: '',
   defaultValue: [],
   options: [],
@@ -249,6 +250,10 @@ MultiSelect.propTypes = {
    * Displays a loading indicator inside of the input.
    */
   loading: PropTypes.bool,
+  /**
+   * Maximum width of the value label in pixels. Use false to disable a maximum width.
+   */
+  maxValueLabelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([false])]), // eslint-disable-line react/no-unused-prop-types
   /**
    * Sets the html name property of the form element.
    */

--- a/pyrene/src/components/MultiSelect/MultiSelect.jsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.jsx
@@ -20,15 +20,23 @@ const MultiValue = ({ data: { value, label }, getValue }) => ( // eslint-disable
   </>
 );
 
+const MultiValueLabel = ({ innerProps, children }) => ( // eslint-disable-line react/prop-types
+  <div title={typeof children === 'string' ? children : undefined} {...innerProps}>
+    {children}
+  </div>
+);
+
 const componentsNormal = {
   LoadingIndicator,
   Option: CustomOption,
+  MultiValueLabel,
 };
 const componentsOptionsInDropdown = {
   Menu: MultiSelectMenuWithOptions,
   MultiValue,
   LoadingIndicator,
   Option: CustomOption,
+  MultiValueLabel,
 };
 
 // Finds the union of value and options, based on options[].value and values[].value being equal.

--- a/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
+++ b/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
@@ -204,7 +204,7 @@ const multiSelectStyle = (props) => ({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
-    maxWidth: props.maxValueLabelWidth === false ? undefined : `${props.maxValueLabelWidth}px`,
+    maxWidth: props.maxValueLabelWidth,
   }),
 
   // "x" next to the label

--- a/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
+++ b/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
@@ -204,7 +204,7 @@ const multiSelectStyle = (props) => ({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
-    maxWidth: '123px',
+    maxWidth: props.maxValueLabelWidth === false ? undefined : `${props.maxValueLabelWidth}px`,
   }),
 
   // "x" next to the label


### PR DESCRIPTION
This implements the following changes in the `MultiSelect` component:
- `title` attribute is added to all value labels (so hovering over a truncated label will show the full one)
- the max width of a value label can be configured (previously hardcoded to `123px`)

Please let me know if you prefer a different API for this component or if the `title` attribute should not be added by default.