### PR TITLE
Allow modal with scrolling content to take full window height

### DIFF
--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -29,11 +29,6 @@ export interface ModalProps {
    */
   closeOnEscape?: boolean,
   /**
-   * If true, the content can use the full height of the screen.
-   * If the content does not fully fit on the screen, scrollbars will be displayed.
-   */
-  contentFullHeight?: boolean;
-  /**
    * Whether the content is padded with the standard padding.
    */
   contentPadding?: boolean,
@@ -113,7 +108,6 @@ const Modal: React.FC<ModalProps> = ({
   canNext = false,
   canPrevious = false,
   closeOnEscape = true,
-  contentFullHeight = false,
   contentPadding = true,
   contentScrolling = true,
   displayNavigationArrows = false,
@@ -223,7 +217,7 @@ const Modal: React.FC<ModalProps> = ({
   const renderContent = () => (
     <>
       <div className={clsx(styles.contentContainer, { [styles.contentScrolling]: contentScrolling })}>
-        <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.contentFullHeight]: contentFullHeight }, { [styles.overlay]: processing })}>
+        <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.overlay]: processing })}>
           { renderCallback() }
         </div>
       </div>

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -29,6 +29,11 @@ export interface ModalProps {
    */
   closeOnEscape?: boolean,
   /**
+   * If true, the content can use the full height of the screen.
+   * If the content does not fully fit on the screen, scrollbars will be displayed.
+   */
+  contentFullHeight?: boolean;
+  /**
    * Whether the content is padded with the standard padding.
    */
   contentPadding?: boolean,
@@ -108,6 +113,7 @@ const Modal: React.FC<ModalProps> = ({
   canNext = false,
   canPrevious = false,
   closeOnEscape = true,
+  contentFullHeight = false,
   contentPadding = true,
   contentScrolling = true,
   displayNavigationArrows = false,
@@ -217,7 +223,7 @@ const Modal: React.FC<ModalProps> = ({
   const renderContent = () => (
     <>
       <div className={clsx(styles.contentContainer, { [styles.contentScrolling]: contentScrolling })}>
-        <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.overlay]: processing })}>
+        <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.contentFullHeight]: contentFullHeight }, { [styles.overlay]: processing })}>
           { renderCallback() }
         </div>
       </div>

--- a/pyrene/src/components/Modal/modal.css
+++ b/pyrene/src/components/Modal/modal.css
@@ -87,7 +87,7 @@
   }
 
   &.contentFullHeight {
-    /* window height - header - footer - 24px padding on both sides */
+    /* window height - header - footer - 24px spacing on both sides */
     max-height: calc(100vh - 64px - 64px - 48px);
   }
 

--- a/pyrene/src/components/Modal/modal.css
+++ b/pyrene/src/components/Modal/modal.css
@@ -86,6 +86,11 @@
     max-height: 512px;
   }
 
+  &.contentFullHeight {
+    /* window height - header - footer - 24px padding on both sides */
+    max-height: calc(100vh - 64px - 64px - 48px);
+  }
+
   &.overlay {
     opacity: 0.5;
     pointer-events: none;

--- a/pyrene/src/components/Modal/modal.css
+++ b/pyrene/src/components/Modal/modal.css
@@ -9,15 +9,21 @@
   left: 0;
   right: 0;
   bottom: 0;
+  padding: 24px;
   background-color: rgba(29, 39, 59, 0.5);
   z-index: 2;
 
   display: flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
 }
 
 .modalContainer {
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  overflow: auto;
   box-sizing: border-box;
 
   background-color: var(--background-light);
@@ -68,6 +74,7 @@
   box-sizing: border-box;
 
   &.contentScrolling {
+    overflow: auto;
     border-top: solid 1px var(--border);
     border-bottom: solid 1px var(--border);
   }
@@ -81,14 +88,7 @@
   }
 
   &.contentScrolling {
-    overflow: auto;
     min-height: 72px;
-    max-height: 512px;
-  }
-
-  &.contentFullHeight {
-    /* window height - header - footer - 24px spacing on both sides */
-    max-height: calc(100vh - 64px - 64px - 48px);
   }
 
   &.overlay {


### PR DESCRIPTION
This allows a modal with scrolling content to take the full window height instead of the hardcoded max `512px`. So instead of always displaying the scrollbars (even if there is enough space left on the screen) it will now use this available space.

If the content is too large for the screen, it will fall back to display the scrollbar.

To make it backwards compatible and not change all existing modals, it is introduced as an additional property.