### PR TITLE
Change Outage to Critical

### DIFF
--- a/kitchensink/src/app/data/foundationsData.jsx
+++ b/kitchensink/src/app/data/foundationsData.jsx
@@ -171,7 +171,7 @@ const semanticColors = [
     title: '',
     colors: [
       {
-        colorName: 'Outage', name: 'neutral-500', darkFont: false, bordered: false,
+        colorName: 'Critical', name: 'neutral-500', darkFont: false, bordered: false,
       },
     ],
   },

--- a/kitchensink/src/app/static/foundations/ColorsPage.jsx
+++ b/kitchensink/src/app/static/foundations/ColorsPage.jsx
@@ -163,7 +163,7 @@ const ColorsPage = () => (
         <ColorRow
           preColumns={1}
           columns={10}
-          title="Outage"
+          title="Critical"
           description=""
           rowHeader={{
             colors: [{


### PR DESCRIPTION
Change the 'Outage' label to 'Critical' in the kitchensink Colors page