### PR TITLE
Cleanup

### DIFF
--- a/pyrene/src/components/Badge/Badge.tsx
+++ b/pyrene/src/components/Badge/Badge.tsx
@@ -30,7 +30,10 @@ export interface BadgeProps {
  * Badges have a label and a mandatory type; they can be made clickable.
  */
 const Badge: React.FC<BadgeProps> = ({
-  label, maxWidth, onClick = () => null, type,
+  label,
+  maxWidth,
+  onClick = () => null,
+  type,
 }: BadgeProps) => (
   <div
     className={clsx(styles.badge, styles[`type-${type}`])}

--- a/pyrene/src/components/CheckboxPopover/CheckboxPopover.tsx
+++ b/pyrene/src/components/CheckboxPopover/CheckboxPopover.tsx
@@ -22,9 +22,7 @@ const CheckboxPopover: FunctionComponent<CheckboxPopoverProps> = ({
 }:CheckboxPopoverProps) => {
   const [displayPopover, setDisplayPopover] = useState(false);
 
-  const togglePopover = () => {
-    setDisplayPopover((prevDisplayPopover) => !prevDisplayPopover);
-  };
+  const togglePopover = () => setDisplayPopover((prevDisplayPopover) => !prevDisplayPopover);
 
   return (
     <div className={clsx(styles.checkboxPopover, { [styles.disabled]: disabled })}>

--- a/pyrene/src/components/Collapsible/Collapsible.tsx
+++ b/pyrene/src/components/Collapsible/Collapsible.tsx
@@ -62,7 +62,7 @@ const Collapsible: React.FC<CollapsibleProps> = ({
 
   const toggleCollapse = (event:React.MouseEvent) => {
     setExpanded((prevExpanded) => !prevExpanded);
-    if (onChange) onChange(event);
+    onChange?.(event);
   };
 
   return (

--- a/pyrene/src/components/DropdownButton/DropdownButton.tsx
+++ b/pyrene/src/components/DropdownButton/DropdownButton.tsx
@@ -87,11 +87,4 @@ const DropdownButton: FunctionComponent<DropdownButtonProps> = ({
 
 DropdownButton.displayName = 'Dropdown Button';
 
-/**
- * defaultProps for compatibilty with kitchensink for pyrene documentation
- */
-DropdownButton.defaultProps = {
-  align: 'start',
-};
-
 export default DropdownButton;

--- a/pyrene/src/components/Icon/Icon.tsx
+++ b/pyrene/src/components/Icon/Icon.tsx
@@ -32,7 +32,7 @@ const Icon: React.FC<IconProps> = ({
   name = '',
   svg = '',
 }: IconProps) => (
-  svg.length > 0 ? (
+  svg?.length > 0 ? (
     <div className={clsx(styles.icon, styles[`type-${type}`])}>
       <img className={styles.svgIcon} src={svg} alt="icon" />
     </div>

--- a/pyrene/src/components/Icon/Icon.tsx
+++ b/pyrene/src/components/Icon/Icon.tsx
@@ -46,5 +46,4 @@ const Icon: React.FC<IconProps> = ({
 
 Icon.displayName = 'Icon';
 
-
 export default Icon;

--- a/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
@@ -32,7 +32,7 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
     )}
     <table className={styles.keyValueBody}>
       <tbody>
-        {rows.length > 0 && rows.map((row: Row) => (
+        {rows && rows.map((row: Row) => (
           <tr
             className={styles.keyValueRow}
             style={row.rowStyle}

--- a/pyrene/src/components/LabelAndValue/LabelAndValue.tsx
+++ b/pyrene/src/components/LabelAndValue/LabelAndValue.tsx
@@ -26,7 +26,10 @@ export interface LabelAndValueProps {
  * Show a label and its value as a highlight.
  */
 const LabelAndValue: React.FC<LabelAndValueProps> = ({
-  label = '', size = 'small', value = '', type = 'neutral',
+  label = '',
+  size = 'small',
+  value = '',
+  type = 'neutral',
 }: LabelAndValueProps) => (
   <div className={clsx(styles['label-and-value'], styles[`label-and-value-${size}`])}>
     <div className={styles.label}>{label}</div>

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -232,15 +232,13 @@ const Modal: React.FC<ModalProps> = ({
   );
 
   return (
-    <>
-      <div className={styles.modalOverlay}>
-        <div className={clsx(styles.modalContainer, styles[size])} role="dialog">
-          {renderHeader && renderHeaderSection()}
-          {loading ? renderLoader() : renderContent()}
-          {renderFooter && renderFooterSection()}
-        </div>
+    <div className={styles.modalOverlay}>
+      <div className={clsx(styles.modalContainer, styles[size])} role="dialog">
+        {renderHeader && renderHeaderSection()}
+        {loading ? renderLoader() : renderContent()}
+        {renderFooter && renderFooterSection()}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -178,7 +178,7 @@ const Modal: React.FC<ModalProps> = ({
 
   const renderFooterSection = () => (
     <>
-      {(Footer && Footer()) || (
+      {(Footer?.()) || (
         <div className={styles.buttonBarContainer}>
           <ButtonBar
             rightButtonSectionElements={createButtonArray(rightButtonBarElements)}
@@ -190,39 +190,35 @@ const Modal: React.FC<ModalProps> = ({
   );
 
   const renderHeaderSection = () => (
-    <>
-      <div className={styles.titleBar}>
-        <span className={styles.title}>
-          {title}
-        </span>
-        <div className={styles.topRightSection}>
-          {displayNavigationArrows && renderNavigationArrows()}
-          <div className={styles.closeButtonContainer}>
-            <ActionBar
-              styling="none"
-              actions={[
-                {
-                  iconName: 'delete',
-                  color: 'neutral300',
-                  active: true,
-                  onClick: onClose,
-                },
-              ]}
-            />
-          </div>
+    <div className={styles.titleBar}>
+      <span className={styles.title}>
+        {title}
+      </span>
+      <div className={styles.topRightSection}>
+        {displayNavigationArrows && renderNavigationArrows()}
+        <div className={styles.closeButtonContainer}>
+          <ActionBar
+            styling="none"
+            actions={[
+              {
+                iconName: 'delete',
+                color: 'neutral300',
+                active: true,
+                onClick: onClose,
+              },
+            ]}
+          />
         </div>
       </div>
-    </>
+    </div>
   );
 
   const renderContent = () => (
-    <>
-      <div className={clsx(styles.contentContainer, { [styles.contentScrolling]: contentScrolling })}>
-        <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.overlay]: processing })}>
-          { renderCallback() }
-        </div>
+    <div className={clsx(styles.contentContainer, { [styles.contentScrolling]: contentScrolling })}>
+      <div className={clsx(styles.content, { [styles.contentPadding]: contentPadding }, { [styles.contentScrolling]: contentScrolling }, { [styles.overlay]: processing })}>
+        { renderCallback() }
       </div>
-    </>
+    </div>
   );
 
   const renderLoader = () => (

--- a/pyrene/src/components/Popover/Popover.tsx
+++ b/pyrene/src/components/Popover/Popover.tsx
@@ -77,16 +77,4 @@ const Popover: FunctionComponent<PopoverProps> = ({
 
 Popover.displayName = 'Popover';
 
-/**
- * defaultProps for compatibilty with kitchensink for pyrene documentation
- */
-Popover.defaultProps = {
-  align: 'start',
-  autoReposition: false,
-  displayPopover: false,
-  distanceToTarget: 8,
-  preferredPosition: ['top', 'bottom'],
-  onClickOutside: () => null,
-};
-
 export default Popover;

--- a/pyrene/src/components/RadioGroup/RadioGroup.tsx
+++ b/pyrene/src/components/RadioGroup/RadioGroup.tsx
@@ -71,9 +71,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
     [key]: true,
   }));
 
-  const onMouseLeave = (key: string) => {
-    setHovered(({ [key]: prev, ...prevHovered }) => prevHovered);
-  };
+  const onMouseLeave = (key: string) => setHovered(({ [key]: prev, ...prevHovered }) => prevHovered);
 
   const lastElementIndex = options.length - 1;
 

--- a/pyrene/src/components/Spacer/Spacer.tsx
+++ b/pyrene/src/components/Spacer/Spacer.tsx
@@ -18,9 +18,4 @@ const Spacer: FunctionComponent<SpacerProps> = ({ size = 'small' }: SpacerProps)
 
 Spacer.displayName = 'Spacer';
 
-// defaultProps for compatibilty with kitchensink for pyrene documentation
-Spacer.defaultProps = {
-  size: 'small',
-};
-
 export default Spacer;

--- a/pyrene/src/components/Stepper/Stepper.tsx
+++ b/pyrene/src/components/Stepper/Stepper.tsx
@@ -53,14 +53,4 @@ const Stepper: FunctionComponent<StepperProps> = ({
 
 Stepper.displayName = 'Stepper';
 
-/**
- * defaultProps for compatibilty with kitchensink for pyrene documentation
- */
-Stepper.defaultProps = {
-  direction: 'right',
-  type: 'bordered',
-  disabled: false,
-  onClick: () => null,
-};
-
 export default Stepper;

--- a/pyrene/src/components/TimeRangeSelector/PresetTimeRanges/PresetTimeRanges.tsx
+++ b/pyrene/src/components/TimeRangeSelector/PresetTimeRanges/PresetTimeRanges.tsx
@@ -3,26 +3,16 @@ import React, { FunctionComponent } from 'react';
 import subMilliseconds from 'date-fns/subMilliseconds';
 import getTime from 'date-fns/getTime';
 import ToggleButtonGroup from '../../ToggleButtonGroup/ToggleButtonGroup';
-
+import { TimeRange } from '../TimeRangeSelectorDefaultProps';
 
 type OnChangeHandler = (newFrom: number, newTo: number, newUpperBound: number, durationInMs: number, presetId: string) => void;
-
-type TimeRange = {
-  durationInMs: number,
-  label: string,
-  id: string,
-};
 
 interface PresetTimeRangesProps {
   currentTimeRangeType?: string,
   disabled?: boolean,
   lowerBound: number,
   onInteract: OnChangeHandler,
-  presetTimeRanges: Array<{
-    durationInMs: number,
-    id: string,
-    label: string,
-  }>,
+  presetTimeRanges: Array<TimeRange>,
   timezone: string,
   upperBound: number,
 }

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.tsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.tsx
@@ -7,7 +7,7 @@ import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
 import clsx from 'clsx';
 import PresetTimeRanges from './PresetTimeRanges/PresetTimeRanges';
 import TimeRangeNavigationBar from './TimeRangeNavigationBar/TimeRangeNavigationBar';
-import PRESET_TIME_RANGES from './TimeRangeSelectorDefaultProps';
+import PRESET_TIME_RANGES, { TimeRange } from './TimeRangeSelectorDefaultProps';
 import styles from './timeRangeSelector.css';
 
 export interface TimeRangeSelectorProps {
@@ -35,11 +35,7 @@ export interface TimeRangeSelectorProps {
    * The preset time ranges to display as preset buttons
    * Type: [{ id: string (required) the id of the preset, label: string (required) label of the preset button displayed to the user, durationInMs: number (required) the duration of the timerange in epoch ms }]
    */
-  presetTimeRanges?: Array<{
-    durationInMs: number,
-    id: string,
-    label: string,
-  }>,
+  presetTimeRanges?: Array<TimeRange>,
   /**
    * Function called if there is some element to be rendered on the rightmost side
    * Type: function

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.tsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeSelector.tsx
@@ -91,11 +91,6 @@ export default class TimeRangeSelector extends Component<TimeRangeSelectorProps,
       durationInMs,
       preserveDuration: false,
     };
-
-    this._onPresetTimeRangeSelected = this._onPresetTimeRangeSelected.bind(this);
-    this._preserveDurationForNavigation = this._preserveDurationForNavigation.bind(this);
-    this._onNavigateBack = this._onNavigateBack.bind(this);
-    this._onNavigateForward = this._onNavigateForward.bind(this);
   }
 
   static getDerivedStateFromProps(props: TimeRangeSelectorProps, state: TimeRangeSelectorState): Partial<TimeRangeSelectorState> | null {
@@ -119,16 +114,16 @@ export default class TimeRangeSelector extends Component<TimeRangeSelectorProps,
    * @private
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _onPresetTimeRangeSelected(newFrom: number, newTo: number, newUpperBound: number, durationInMs: number, presetId: string): void {
+  _onPresetTimeRangeSelected = (newFrom: number, newTo: number, newUpperBound: number, durationInMs: number, presetId: string): void => {
     this.setState({
       durationInMs, // We need to store it, otherwise if we reach the lower/upper bound we will start to use less milliseconds with the steppers
     },
     () => {
       this.props.onChange(newFrom, newTo);
     });
-  }
+  };
 
-  _onNavigateBack(): void {
+  _onNavigateBack = (): void => {
     const fromDiff = subMilliseconds(this.props.from, this.state.durationInMs);
     const toDiff = subMilliseconds(this.props.to, this.state.durationInMs);
 
@@ -139,9 +134,9 @@ export default class TimeRangeSelector extends Component<TimeRangeSelectorProps,
       ? addMilliseconds(newFrom, this.state.durationInMs)
       : toDiff;
     return this.props.onChange(newFrom, Math.min(getTime(newTo), this.props.upperBound));
-  }
+  };
 
-  _onNavigateForward(): void {
+  _onNavigateForward = (): void => {
     const fromDiff = addMilliseconds(this.props.from, this.state.durationInMs);
     const toDiff = addMilliseconds(this.props.to, this.state.durationInMs);
 
@@ -152,13 +147,13 @@ export default class TimeRangeSelector extends Component<TimeRangeSelectorProps,
       ? addMilliseconds(newTo, this.state.durationInMs)
       : fromDiff;
     return this.props.onChange(Math.max(getTime(newFrom), this.props.lowerBound), newTo);
-  }
+  };
 
   /**
    * Checks whether the component has a preset timerange selected when navigating; if yes, we should preserve the current durationInMs.
    * @private
    */
-  _preserveDurationForNavigation(navigateCallback: () => void): void {
+  _preserveDurationForNavigation = (navigateCallback: () => void): void => {
     const foundTimeRangeType = this.props?.presetTimeRanges?.find?.((preset) => preset.durationInMs === this.state.durationInMs);
     if (foundTimeRangeType) {
       this.setState({ preserveDuration: true }, () => {
@@ -167,7 +162,7 @@ export default class TimeRangeSelector extends Component<TimeRangeSelectorProps,
     } else {
       navigateCallback();
     }
-  }
+  };
 
   render(): JSX.Element {
     const currentTimeRangeType = this.props?.presetTimeRanges?.find?.((preset) => preset.durationInMs === this.state.durationInMs); // Try to find if the timerange matches an initial preset


### PR DESCRIPTION
1. Use` class properties`, like at [Facebook](https://github.com/facebook/react/issues/9851), so no need to `bind` context in methods.
2. `Reuse` Type.
3. Remove useless `React.Fragment`
4. Enhanced `code readability`
5. Use chaining operator with [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#optional_chaining_with_function_calls)
6. Enhance `check`
7. Remove useless bracket `{` in function 