### PR TITLE
code cleanup [improvement]

### DIFF
--- a/pyrene/src/components/Badge/Badge.tsx
+++ b/pyrene/src/components/Badge/Badge.tsx
@@ -32,7 +32,7 @@ export interface BadgeProps {
 const Badge: React.FC<BadgeProps> = ({
   label,
   maxWidth,
-  onClick = () => null,
+  onClick,
   type,
 }: BadgeProps) => (
   <div

--- a/pyrene/src/components/CheckboxPopover/CheckboxList.tsx
+++ b/pyrene/src/components/CheckboxPopover/CheckboxList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { FunctionComponent } from 'react';
 
 import Checkbox from '../Checkbox/Checkbox';
@@ -20,7 +21,7 @@ const CheckboxList: FunctionComponent<CheckboxListProps> = ({
   onRestoreDefault,
   listItems,
   onItemClick,
-}: CheckboxListProps) => (
+}) => (
   <div className={styles.checkboxList}>
     <div className={styles.listHeader}>
       <Button label="Restore default" type="action" onClick={() => onRestoreDefault()} />

--- a/pyrene/src/components/DropdownButton/OptionsItem.tsx
+++ b/pyrene/src/components/DropdownButton/OptionsItem.tsx
@@ -1,14 +1,14 @@
+/* eslint-disable react/prop-types */
 import React, { FunctionComponent } from 'react';
 
 import styles from './optionsItem.css';
-
 
 export interface OptionsItemProps {
   label: string,
   onClick: () => void,
 }
 
-const OptionsItem: FunctionComponent<OptionsItemProps> = ({ label, onClick }: OptionsItemProps) => (
+const OptionsItem: FunctionComponent<OptionsItemProps> = ({ label, onClick }) => (
   <button
     className={styles.container}
     onClick={onClick}

--- a/pyrene/src/components/DropdownButton/OptionsList.tsx
+++ b/pyrene/src/components/DropdownButton/OptionsList.tsx
@@ -1,7 +1,6 @@
+/* eslint-disable react/prop-types */
 import React, { FunctionComponent } from 'react';
-
 import OptionsItem, { OptionsItemProps } from './OptionsItem';
-
 import styles from './optionsList.css';
 
 export interface OptionsListProps {
@@ -9,7 +8,7 @@ export interface OptionsListProps {
   onClick: () => void,
 }
 
-const OptionsList: FunctionComponent<OptionsListProps> = ({ actions, onClick }: OptionsListProps) => (
+const OptionsList: FunctionComponent<OptionsListProps> = ({ actions, onClick }) => (
   <div className={styles.actionContainer}>
     {actions.map((action) => (
       <OptionsItem

--- a/pyrene/src/components/Filter/Filter.tsx
+++ b/pyrene/src/components/Filter/Filter.tsx
@@ -36,7 +36,7 @@ const Filter: FunctionComponent<FilterProps> = ({
   disabled = false,
   filters = [],
   negatable = false,
-  onFilterSubmit = () => null,
+  onFilterSubmit,
 }: FilterProps) => {
 
   if (disabled) {

--- a/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react';
+ import React, { CSSProperties, ReactNode } from 'react';
 import styles from './keyValueTable.css';
 
 type Row = {
@@ -32,7 +32,7 @@ const KeyValueTable: React.FC<KeyValueTableProps> = ({
     )}
     <table className={styles.keyValueBody}>
       <tbody>
-        {rows && rows.map((row: Row) => (
+        {rows && rows.map((row) => (
           <tr
             className={styles.keyValueRow}
             style={row.rowStyle}

--- a/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/pyrene/src/components/KeyValueTable/KeyValueTable.tsx
@@ -1,4 +1,4 @@
- import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, ReactNode } from 'react';
 import styles from './keyValueTable.css';
 
 type Row = {

--- a/pyrene/src/components/Modal/Modal.examples.tsx
+++ b/pyrene/src/components/Modal/Modal.examples.tsx
@@ -1,18 +1,17 @@
+/* eslint-disable react/display-name */
 import React from 'react';
 import Placeholder from '../../examples/Placeholder';
 
 const Modal = {
   props: {
-    renderCallback: function displayPlaceHolder(): React.ReactElement {
-      return (<Placeholder label="Content" width={392} />);
-    },
+    renderCallback: (): React.ReactElement => <Placeholder label="Content" width={392} />,
     canNext: true,
     canPrevious: true,
     displayNavigationArrows: true,
     size: 'small',
     title: 'Modal',
     leftButtonBarElements: [
-      { type: 'danger', label: 'Delete', action: ():void => {} },
+      { type: 'danger', label: 'Delete', action: (): void => {} },
       { type: 'ghost', label: 'Disabled', action: (): void => {} },
     ],
     rightButtonBarElements: [

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import Loader from '../Loader/Loader';
 import ActionBar from '../ActionBar/ActionBar';
 import { IconNames } from '../types';
 
-interface ButtonBarProps{
+interface ButtonBarProps {
   action: () => void,
   disabled?: boolean,
   icon?: keyof IconNames,

--- a/pyrene/src/components/Modal/Modal.tsx
+++ b/pyrene/src/components/Modal/Modal.tsx
@@ -97,6 +97,19 @@ export interface ModalProps {
   title?: string,
 }
 
+const createButtonArray = (buttonInfo: ButtonBarProps[]) => (
+  buttonInfo.map((buttonProps) => (
+    <Button
+      key={buttonProps.label}
+      loading={buttonProps.loading}
+      icon={buttonProps.icon}
+      type={buttonProps.type}
+      label={buttonProps.label}
+      disabled={buttonProps.disabled}
+      onClick={buttonProps.action}
+    />
+  ))
+);
 
 /**
  * The modal view is used when full attention on an action or a process is required. The modal has an invasive experience and no other interactions on the main page can be accessed while active.
@@ -127,7 +140,7 @@ const Modal: React.FC<ModalProps> = ({
   title = '',
 }: ModalProps) => {
 
-  const escFunction = useCallback((event:KeyboardEvent) => {
+  const escFunction = useCallback((event: KeyboardEvent) => {
     if (onClose && event.key === 'Escape' && closeOnEscape) {
       onClose();
     }
@@ -142,20 +155,6 @@ const Modal: React.FC<ModalProps> = ({
       document.removeEventListener('keydown', escFunction, false);
     };
   }, [escFunction]);
-
-  const createButtonArray = (buttonInfo: ButtonBarProps[]) => (
-    buttonInfo.map((buttonProps) => (
-      <Button
-        key={buttonProps.label}
-        loading={buttonProps.loading}
-        icon={buttonProps.icon}
-        type={buttonProps.type}
-        label={buttonProps.label}
-        disabled={buttonProps.disabled}
-        onClick={buttonProps.action}
-      />
-    ))
-  );
 
   const renderNavigationArrows = () => (
     <ActionBar

--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -152,9 +152,9 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
     keepMenuOnSelect = false,
     loading = false,
     name = '',
-    onBlur = () => null,
-    onChange = () => null,
-    onFocus = () => null,
+    onBlur,
+    onChange,
+    onFocus,
     placeholder = '',
     required = false,
     selectedOptionsInDropdown = false,
@@ -176,9 +176,9 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
       if (value.length > 0) {
         const distinctNewValue = newValue.filter((o) => value.findIndex((exO) => exO.label.toLowerCase() === o.label.toLowerCase()) < 0);
         setHasPastedDuplicates(distinctNewValue.length < delimitedValues.length);
-        onChange([...value, ...distinctNewValue]);
+        onChange?.([...value, ...distinctNewValue]);
       } else {
-        onChange(newValue);
+        onChange?.(newValue);
       }
 
       // Prevents the pasted data from becoming inputValue
@@ -212,11 +212,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             isInvalid={invalid}
             isLoading={loading}
             // wrapping type and key into target so it better reflects the api that input event has (there is also event.target.name)
-            onChange={(option) => {
-              if (option) {
-                onChange(option, { target: { type: 'multiSelect', name: name, value: option } });
-              }
-            }}
+            onChange={(option: any) => onChange?.(option, { target: { type: 'multiSelect', name: name, value: option } })}
             onInputChange={(input) => {
               if (input.length > 0) {
                 setHasPastedDuplicates(false);
@@ -252,11 +248,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             isDisabled={disabled}
             isInvalid={invalid}
             isLoading={loading}
-            onChange={(option) => {
-              if (option) {
-                onChange(option, { target: { type: 'multiSelect', name: name, value: option } });
-              }
-            }}
+            onChange={(option: any) => onChange?.(option, { target: { type: 'multiSelect', name: name, value: option } })}
             onBlur={onBlur}
             onFocus={onFocus}
             name={name}

--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -202,7 +202,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             styles={MultiSelectStyle(props) as any}
             components={(selectedOptionsInDropdown ? componentsOptionsInDropdown : componentsNormal) as SelectComponentsConfig<Option, true>}
             // Sets the internal value to "" in case of null or undefined
-            getOptionValue={(option) => (option.value !== null && typeof option.value !== 'undefined' ? option.value : '')}
+            getOptionValue={(option) => option.value ?? ''}
             placeholder={placeholder}
             options={opts}
             value={value}
@@ -243,7 +243,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             styles={MultiSelectStyle(props) as any}
             components={(selectedOptionsInDropdown ? componentsOptionsInDropdown : componentsNormal) as SelectComponentsConfig<Option, true>}
             // Sets the internal value to "" in case of null or undefined
-            getOptionValue={(option) => ((option.value !== null && typeof option.value !== 'undefined') ? option.value : '')}
+            getOptionValue={(option) => option.value ?? ''}
             placeholder={placeholder}
             options={opts}
             value={value}

--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -202,7 +202,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             styles={MultiSelectStyle(props) as any}
             components={(selectedOptionsInDropdown ? componentsOptionsInDropdown : componentsNormal) as SelectComponentsConfig<Option, true>}
             // Sets the internal value to "" in case of null or undefined
-            getOptionValue={(option) => option.value ?? ''}
+            getOptionValue={(option) => (option.value !== null && typeof option.value !== 'undefined' ? option.value : '')}
             placeholder={placeholder}
             options={opts}
             value={value}
@@ -243,7 +243,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             styles={MultiSelectStyle(props) as any}
             components={(selectedOptionsInDropdown ? componentsOptionsInDropdown : componentsNormal) as SelectComponentsConfig<Option, true>}
             // Sets the internal value to "" in case of null or undefined
-            getOptionValue={(option) => option.value ?? ''}
+            getOptionValue={(option) => ((option.value !== null && typeof option.value !== 'undefined') ? option.value : '')}
             placeholder={placeholder}
             options={opts}
             value={value}

--- a/pyrene/src/components/RadioButton/RadioButton.tsx
+++ b/pyrene/src/components/RadioButton/RadioButton.tsx
@@ -18,7 +18,7 @@ export interface RadioButtonBaseProps {
   /**
    * Javascript event handler.
    */
-  hovered?: { [key: string]: boolean },
+  hovered?: Record<string, boolean>,
   /**
    * Sets ID of radio button
    */

--- a/pyrene/src/components/RadioGroup/RadioGroup.tsx
+++ b/pyrene/src/components/RadioGroup/RadioGroup.tsx
@@ -44,7 +44,7 @@ export interface RadioGroupProps {
   value?: number | string,
 }
 
-type HoveredState = { [key: string]: boolean };
+type HoveredState = Record<string, boolean>;
 
 /**
  * RadioGroup creates a collection of radio buttons that allow the user to select an option from a set.
@@ -100,7 +100,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
                   invalid={option.invalid || invalid}
                   label={option.label}
                   name={name}
-                  onChange={((val, event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value, event))}
+                  onChange={(val, event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value, event)}
                   readonly={option.readonly}
                   value={option.value}
                 />

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -82,7 +82,7 @@ export type SingleSelectProps<ValueType = DefaultValueType> = {
   /**
    * Event Handler. Param option: {value: , label:}
    */
-  onChange?: (option: SingleSelectOption<ValueType>, evt: { target: { type: string; name: string; value: any; } }) => void;
+  onChange?: (option: SingleSelectOption<ValueType>, evt: { target: { type: string; name: string; value: SingleSelectOption<ValueType> } }) => void;
   /**
    * Focus event handler, use this to dynamically fetch options.
    */

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -186,7 +186,7 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
       LoadingIndicator,
       Option: CustomOption,
     },
-    getOptionValue: (option: any) => ((option.value !== null && typeof option.value !== 'undefined') ? option.value : ''),
+    getOptionValue: (option: any) => option.value ?? '',
     placeholder: placeholder,
     options: optionsObj,
     value: value,

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -215,7 +215,7 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
 
   return (
     <div className={clsx(styles.selectContainer, { [styles.disabled]: disabled })}>
-      {title && <div className={clsx(styles.selectTitle, { [styles.required]: (required && !disabled) })}>{title}</div>}
+      {title && <div className={clsx(styles.selectTitle, { [styles.required]: required && !disabled })}>{title}</div>}
 
       {creatable ? <CreatableSelect {...selectProps} /> : <Select {...selectProps} /> }
 

--- a/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/TRSStepper/TRSStepper.tsx
+++ b/pyrene/src/components/TimeRangeSelector/TimeRangeNavigationBar/ArrowSelector/TRSStepper/TRSStepper.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { FunctionComponent } from 'react';
 import clsx from 'clsx';
 import styles from './trsStepper.css';
@@ -29,7 +30,7 @@ const TRSStepper: FunctionComponent<TRSStepperProps> = ({
   disabled = false,
   inactive = false,
   onClick,
-}: TRSStepperProps) => {
+}) => {
   const capitalisedDirection = direction.charAt(0).toUpperCase() + direction.slice(1);
   return (
     <button


### PR DESCRIPTION
# Done in that PR

1. Let the TS compiler do `type inference` on its own.
2. Fix bug happening while `clearing up` the input field filter introduced in [PR-176](https://github.com/open-ch/pyrene/pull/176/files) (`onChange`)
3. Stop unnecessary `call of void` `event handler`.
4. Remove useless `type of parameter` in FunctionComponent for non-public component.
5. `Nullish` operator
6. Remove useless `parenthesis`