### PR TITLE
Reset selected row state when fetching data

### DIFF
--- a/pyrene/src/components/Table/Table.jsx
+++ b/pyrene/src/components/Table/Table.jsx
@@ -121,11 +121,14 @@ export default class Table extends React.Component {
     // Server-side props
     manual: this.props.manual,
 
-    onFetchData: (rts) => ((this.state.pageSize !== rts.pageSize) ? this.props.onFetchData({
-      page: 0, pageCount: 0, pageSize: rts.pageSize, sorting: rts.sorted, filters: this.props.filterValues,
-    }) : this.props.onFetchData({
-      page: rts.page, pageCount: this.props.pages, pageSize: rts.pageSize, sorting: rts.sorted, filters: this.props.filterValues,
-    })),
+    onFetchData: (rts) => {
+      this.resetSelection();
+      return ((this.state.pageSize !== rts.pageSize) ? this.props.onFetchData({
+        page: 0, pageCount: 0, pageSize: rts.pageSize, sorting: rts.sorted, filters: this.props.filterValues,
+      }) : this.props.onFetchData({
+        page: rts.page, pageCount: this.props.pages, pageSize: rts.pageSize, sorting: rts.sorted, filters: this.props.filterValues,
+      }));
+    },
   };
 
   onManualFilterChange = (values) => {


### PR DESCRIPTION
When entries are added or removed from the table, we are not resetting the status of the selected rows, unlike when operations on pagination are performed.
This cause an inconsistent status on the selected items state which is particularly problematic when entries are deleted, since the state will keep selected entries that are in reality not part of the available data anymore