### PR TITLE
force re-render react table when number of results changed

### DIFF
--- a/pyrene/src/components/Table/Table.jsx
+++ b/pyrene/src/components/Table/Table.jsx
@@ -310,6 +310,7 @@ export default class Table extends React.Component {
           {...this.commonStaticProps}
           {...commonVariableProps}
           {...multiTableProps}
+          key={this.props.numberOfResults}
         />
       )
       : (


### PR DESCRIPTION
The onFetchData is called only once in `componentDidMount`.
By adding this key using the number of results, it forces the component to rerender (i.e. call `componentDidMount` again) after deleting an entry or whenever the number changes