### PR TITLE
pyrene:develop script working [improvement]

### DIFF
--- a/kitchensink/package.json
+++ b/kitchensink/package.json
@@ -25,7 +25,7 @@
     "watch:kitchensink-pyrene": "concurrently --kill-others npm:watch:pyrene npm:watch:kitchensink",
     "watch:all": "concurrently --kill-others npm:watch:tuktuktwo npm:watch:pyrene npm:watch:pyrene-graphs npm:watch:kitchensink",
     "develop:all": "npm install && npm run expose:all && npm run link:all && npm run watch:all",
-    "develop:pyrene": "npm install && npm run expose:pyrene && npm link @osag/pyrene && npm run watch:kitchensink-pyrene",
+    "develop:pyrene": "cd .. && npm i && cd - && npm install && npm run expose:pyrene && npm link @osag/pyrene && npm run watch:kitchensink-pyrene",
     "clean": "rm -rf dist node_modules",
     "prebuild": "npm install",
     "build": "webpack",


### PR DESCRIPTION
# Done in the present PR

While running the `develop:pyrene` npm script in the kitchensink you might get the following exception.

This is due to the root package.json introduced with the **storybook** support in the entire repo.


![Screenshot 2021-10-29 at 08 48 16](https://user-images.githubusercontent.com/6510794/139390419-82d0d577-80ff-4033-91d9-ac4117bafb4d.png)
