### PR TITLE
dependencies install order [improvement]

### DIFF
--- a/kitchensink/package.json
+++ b/kitchensink/package.json
@@ -25,7 +25,7 @@
     "watch:kitchensink-pyrene": "concurrently --kill-others npm:watch:pyrene npm:watch:kitchensink",
     "watch:all": "concurrently --kill-others npm:watch:tuktuktwo npm:watch:pyrene npm:watch:pyrene-graphs npm:watch:kitchensink",
     "develop:all": "npm install && npm run expose:all && npm run link:all && npm run watch:all",
-    "develop:pyrene": "cd .. && npm i && cd - && npm install && npm run expose:pyrene && npm link @osag/pyrene && npm run watch:kitchensink-pyrene",
+    "develop:pyrene": "npm i --prefix ../pyrene && npm i --prefix .. && npm install && npm run expose:pyrene && npm link @osag/pyrene && npm run watch:kitchensink-pyrene",
     "clean": "rm -rf dist node_modules",
     "prebuild": "npm install",
     "build": "webpack",


### PR DESCRIPTION
# Done in the present PR

While running `npm run develop:pyene` in `kitchensink` we first have to install the dependencies at the root of the project. This fix was done in that [PR](https://github.com/open-ch/pyrene/pull/209).

There is still the problem remaining : 
 > the dependencies of the root directory **depend** on the dependencies of the `pyrene` subproject.

# Example of problem that the present PR fixes

![Screenshot 2021-11-08 at 11 12 12](https://user-images.githubusercontent.com/6510794/140724165-6cdc7f49-df6a-4f27-9afe-c63ebf81092e.png)

