### PR TITLE
typing remove unit test [improvement]

### DIFF
--- a/pyrene/src/components/Accordion/Accordion.tsx
+++ b/pyrene/src/components/Accordion/Accordion.tsx
@@ -9,7 +9,7 @@ export interface AccordionProps {
   /**
    * The list of sections for the accordion. A section is { expanded?: boolean, iconProps?: IconProps, renderContent: () => React.ReactNode, title: string | (() => React.ReactNode)}
    */
-  sections: SectionProps[]
+  sections: SectionProps[];
 }
 
 /**

--- a/pyrene/src/components/Accordion/Section.tsx
+++ b/pyrene/src/components/Accordion/Section.tsx
@@ -7,19 +7,19 @@ export interface SectionProps {
   /**
    * True to initially display this section as expanded (defaults to false)
    */
-  expanded?: boolean
+  expanded?: boolean;
   /**
    * Icon on the left of the section header
    */
-  iconProps?: IconProps
+  iconProps?: IconProps;
   /**
    * Render prop for the section content
    */
-  renderContent: () => React.ReactNode
+  renderContent: () => React.ReactNode;
   /**
    * Title string, or render prop for custom titles
    */
-  title: string | (() => React.ReactNode)
+  title: string | (() => React.ReactNode);
 }
 
 const Section: React.FC<SectionProps> = ({

--- a/pyrene/src/components/ArrowPopover/ArrowPopover.spec.tsx
+++ b/pyrene/src/components/ArrowPopover/ArrowPopover.spec.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ArrowPopover, { Alignment, arrowPosition, PreferredPos } from './ArrowPopover';
+import ArrowPopover, { ArrowPopoverProps, arrowPosition } from './ArrowPopover';
 
-const props = {
-  align: 'center' as Alignment,
+const props: ArrowPopoverProps = {
+  align: 'center',
   closePopover: jest.fn(),
   distanceToTarget: 12,
-  preferredPosition: ['top', 'left'] as PreferredPos,
+  preferredPosition: ['top', 'left'],
   displayPopover: false,
   popoverContent: <div />,
+  children: <div />,
 };
 
 const children = <div />;
@@ -29,7 +30,7 @@ describe('<ArrowPopover />', () => {
       const lengthSide = 20;
       const arrowWidth = (lengthSide * Math.sqrt(2)) / 2;
 
-      const popoverRect: ClientRect = {
+      const popoverRect = {
         top: 100,
         left: 100,
         height: 100,
@@ -38,7 +39,7 @@ describe('<ArrowPopover />', () => {
         right: 0,
       };
 
-      const targetRect: ClientRect = {
+      const targetRect = {
         top: 200,
         left: 200,
         height: 40,
@@ -372,29 +373,6 @@ describe('<ArrowPopover />', () => {
       const result = arrowPosition('right', targetRect, popoverRect);
 
       expect(result).toEqual({ top: arrowWidth, left: -10, lengthSide });
-    });
-
-    it('unvalid position', () => {
-
-      const popoverRect = {
-        top: 100,
-        left: 100,
-        height: 100,
-        width: 100,
-        bottom: 0,
-        right: 0,
-      };
-
-      const targetRect = {
-        top: 200,
-        left: 200,
-        height: 40,
-        width: 40,
-        bottom: 0,
-        right: 0,
-      };
-
-      expect(() => { arrowPosition('test', targetRect, popoverRect); }).toThrow(new Error('Not a valid position: test'));
     });
   });
 

--- a/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
+++ b/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
@@ -10,7 +10,7 @@ interface ArrowPosition {
   lengthSide: number,
 }
 
-type TargetRect = Omit<DOMRect, 'x' | 'y'>
+type TargetRect = Omit<DOMRect, 'x' | 'y' | 'toJSON'>;
 
 export interface ArrowPopoverProps {
   /**

--- a/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
+++ b/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
@@ -20,7 +20,7 @@ export interface ArrowPopoverProps {
   /**
    * Action element
    */
-  children: React.ReactNode,
+  children: React.ReactElement,
   /**
    * Function to close the popover.
    */

--- a/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
+++ b/pyrene/src/components/ArrowPopover/ArrowPopover.tsx
@@ -1,25 +1,26 @@
 import React, { useEffect, useRef, useCallback } from 'react';
-import Popover from '../Popover/Popover';
+import { Position } from 'react-tiny-popover';
+import Popover, { PopoverProps } from '../Popover/Popover';
 
 import styles from './arrowPopover.css';
 
-export type PreferredPos = ('top' | 'right' | 'bottom' | 'left')[];
-export type Alignment = 'start' | 'center' | 'end';
 interface ArrowPosition {
   top: number,
   left: number,
   lengthSide: number,
 }
 
+type TargetRect = Omit<DOMRect, 'x' | 'y'>
+
 export interface ArrowPopoverProps {
   /**
    * Sets the alignment of the popover.
    */
-  align?: Alignment,
+  align?: PopoverProps['align'],
   /**
    * Action element
    */
-  children: React.ReactElement,
+  children: React.ReactNode,
   /**
    * Function to close the popover.
    */
@@ -27,22 +28,22 @@ export interface ArrowPopoverProps {
   /**
    * Whether to display the popover.
    */
-  displayPopover: boolean,
+  displayPopover: PopoverProps['displayPopover'],
   /**
    * Sets the distance of the popover to its target.
    */
-  distanceToTarget?: number,
+  distanceToTarget?: PopoverProps['distanceToTarget'],
   /**
    * Content rendered in popover
    */
-  popoverContent: React.ReactElement,
+  popoverContent: React.ReactNode,
   /**
    * Sets the preferred position array ordered by priority for auto repositioning.
    */
-  preferredPosition?: PreferredPos,
+  preferredPosition?: Array<Position>,
 }
 
-export const arrowPosition = (position: string, targetRect: ClientRect, popoverRect: ClientRect): ArrowPosition => {
+export const arrowPosition = (position: Position, targetRect: TargetRect, popoverRect: TargetRect): ArrowPosition => {
   // Square
   const lengthSide = 20;
   const arrowWidth = (lengthSide * Math.sqrt(2)) / 2;
@@ -72,13 +73,11 @@ export const arrowPosition = (position: string, targetRect: ClientRect, popoverR
       left = left + arrowWidth > widthOverflowPoint ? widthOverflowPoint - arrowWidth : left;
       left = left < arrowWidth ? arrowWidth : left;
       break;
-    case 'right':
+    // right
+    default:
       left = -lengthSide / 2;
       top = top + arrowWidth > heightOverflowPoint ? heightOverflowPoint - arrowWidth : top;
       top = top < arrowWidth ? arrowWidth : top;
-      break;
-    default:
-      throw new Error(`Not a valid position: ${position}`);
   }
   return { top, left, lengthSide };
 };
@@ -96,7 +95,7 @@ const ArrowPopover: React.FC<ArrowPopoverProps> = ({
   distanceToTarget = 20,
 }: ArrowPopoverProps) => {
 
-  const node = useRef<HTMLDivElement>(null);
+  const node = useRef<HTMLDivElement | null>(null);
 
   const handleClick = useCallback((e:MouseEvent) => {
     if (closePopover && node && node.current && !node.current.contains(e.target as Node)) {

--- a/pyrene/src/components/Popover/Popover.tsx
+++ b/pyrene/src/components/Popover/Popover.tsx
@@ -13,7 +13,7 @@ export interface PopoverProps {
   /**
   * Wrapped component(s) that the popover is using for its positioning.
   */
-  children: JSX.Element,
+  children: React.ReactNode,
   /**
   * Whether to display the popover.
   */

--- a/pyrene/src/components/Popover/Popover.tsx
+++ b/pyrene/src/components/Popover/Popover.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent } from 'react';
 import TinyPopover, { Position, PopoverProps as TinyPopoverProps } from 'react-tiny-popover';
 
+type TargetRect = Omit<DOMRect, 'x' | 'y' | 'toJSON'>;
+
 export interface PopoverProps {
   /**
    * Sets the alignment of the popover.
@@ -13,7 +15,7 @@ export interface PopoverProps {
   /**
   * Wrapped component(s) that the popover is using for its positioning.
   */
-  children: React.ReactNode,
+  children: JSX.Element,
   /**
   * Whether to display the popover.
   */
@@ -33,7 +35,7 @@ export interface PopoverProps {
   /**
   * Sets the content displayed inside the popover.
   */
-  renderPopoverContent: (position: Position, nudgedLeft: number, nudgedTop: number, targetRect: ClientRect, popoverRect: ClientRect) => JSX.Element,
+  renderPopoverContent: (position: Position, nudgedLeft: number, nudgedTop: number, targetRect: TargetRect, popoverRect: TargetRect) => JSX.Element,
 }
 
 /**


### PR DESCRIPTION
# Done in the present PR
- Fix `deprecated` type `ClientRect` (see screenshot)
- Type `reusability`
- Remove irrelevant `unit test` (already covered by static typing)
- Enhance syntax of TypeScript `interface`

![Screenshot 2021-11-09 at 08 51 18](https://user-images.githubusercontent.com/6510794/140886257-b9f779e4-1830-4d28-afba-21ced38c7c95.png)


