### PR TITLE
made multiselect options optional

### DIFF
--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -70,7 +70,7 @@ export interface MultiSelectProps {
   /**
    * Data input array. Type: [{ value: string (required), label: string (required), invalid: bool }]
    */
-  options: ReadonlyArray<Option>,
+  options?: ReadonlyArray<Option>,
   /**
    * Sets the placeholder label.
    */
@@ -161,7 +161,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
     sorted = true,
     title = '',
     value = [],
-    options,
+    options = [],
   } = props;
 
   const [hasPastedDuplicates, setHasPastedDuplicates] = useState(false);


### PR DESCRIPTION
Sometimes the options are not available, so it shouldn't be a mandatory field. Also many of the existing uses of this component don't have options.