### PR TITLE
used a function for onChange handler instead of undefined

### DIFF
--- a/pyrene/src/components/Checkbox/Checkbox.tsx
+++ b/pyrene/src/components/Checkbox/Checkbox.tsx
@@ -142,7 +142,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
         className={styles.checkbox}
         type="checkbox"
         checked={value}
-        onChange={!disabled ? (event) => onChange?.(event.target.checked, event) : undefined}
+        onChange={!disabled ? (event) => onChange?.(event.target.checked, event) : () => null}
         onClick={(e) => e.stopPropagation()}
         name={name}
       />


### PR DESCRIPTION
There's complaint that 'You provided a `checked` prop to a form field without an `onChange` handler'. So the onChange function shouldn't be undefined.