### PR TITLE
added 'disabled' state to table actions

### DIFF
--- a/pyrene/src/components/Table/Table.spec.jsx
+++ b/pyrene/src/components/Table/Table.spec.jsx
@@ -64,6 +64,11 @@ describe('<Table />', () => {
       label: 'Always',
       callback: onClick,
       active: 'always',
+    }, {
+      icon: 'filter',
+      label: 'Disabled',
+      callback: () => null,
+      active: 'disabled',
     }];
 
     const wrapper = shallow(<Table {...buttonTestProps} />);
@@ -82,6 +87,8 @@ describe('<Table />', () => {
       .simulate('click');
     expect(onClick)
       .toHaveBeenCalledTimes(3);
+
+    expect(wrapper.find('Button[label="Disabled"]').props().disabled).toBe(true);
   });
 
 });

--- a/pyrene/src/components/Table/Table.tsx
+++ b/pyrene/src/components/Table/Table.tsx
@@ -80,7 +80,7 @@ export interface TableState {
 }
 
 export interface Action {
-  active: 'single' | 'multi' | 'always',
+  active: 'single' | 'multi' | 'always' | 'disabled',
   callback: (row: Array<string | number>) => void,
   icon?: keyof IconNames,
   label: string,
@@ -89,7 +89,7 @@ export interface Action {
 
 export interface TableProps<R={}> {
   /**
-   * Sets the table actions. Type: [{ icon: string, label: string (required), callback: func (required), active: oneOf('single', 'multi', 'always') (required) }]
+   * Sets the table actions. Type: [{ icon: string, label: string (required), callback: func (required), active: oneOf('single', 'multi', 'always', 'disabled') (required) }]
    */
   actions?: Array<Action>,
   /**
@@ -396,7 +396,11 @@ export default class Table<R> extends React.Component<TableProps<R>, TableState>
       return false;
     }
 
-    // enable actions based on selection length and actionTypex
+    if (actionType === 'disabled') {
+      return false;
+    }
+
+    // enable actions based on selection length and actionType
     if (actionType === 'always') {
       return true;
     }


### PR DESCRIPTION
Sometimes some of the table actions need to be disabled conditionally. Existing uses of this component has been giving the 'active' a 'disabled' value, and this was OK before the TS conversion as 'disabled' didn't match the predefined 'single', 'multi'  and 'always' and will return a 'false', now with TS it's stricter and 'disabled' gets warning. So we might as well just add this as one of the allowed strings.