### PR TITLE
fixed TreeTableCell display issue due to misplacement of '(' and ')'

### DIFF
--- a/pyrene/src/components/TreeTable/TreeTableCell/TreeTableCell.tsx
+++ b/pyrene/src/components/TreeTable/TreeTableCell/TreeTableCell.tsx
@@ -31,14 +31,14 @@ function TreeTableCell<R extends object = {}>({
   return (
     <div style={style} className={styles.treeTableCell}>
 
-      {firstColumn && parent
+      {firstColumn && (parent
         ? (
           <div
             className={clsx(styles.pivotIcon, { [styles.sectionOpen]: sectionOpen }, 'pyreneIcon-chevronDown')}
             onClick={onExpandClick}
           />
         )
-        : <div className={styles.iconSpaceholder} />}
+        : <div className={styles.iconSpaceholder} />)}
 
       {/* Use renderCallback if there is one defined for this column */}
 


### PR DESCRIPTION
The misplacement of the `()` led to that the space holder was always there