### PR TITLE
FIX: Select title line height

### DIFF
--- a/pyrene/src/components/SingleSelect/select.css
+++ b/pyrene/src/components/SingleSelect/select.css
@@ -16,7 +16,7 @@
   font-weight: 500;
   text-align: left;
   color: var(--neutral-500);
-  height: 12px;
+  line-height: 12px;
   margin-bottom: 4px;
 
   &.required:after {


### PR DESCRIPTION
We need to specify line height as 12px for select title (as we do for
other form components). I think the `height` that was set here was a
typo and it was meant to be `line-height` which is why I replaced that
property.

This is important because otherwise it will follow line height
of whatever parent element so it will certainly look weird most of the
time unlike the other form components that specify it