### PR TITLE
FIX: multiselect placeholder alignment

### DIFF
--- a/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
+++ b/pyrene/src/components/MultiSelect/multiSelectCSS.jsx
@@ -16,6 +16,7 @@ const multiSelectStyle = (props) => ({
     fontFamily: 'FiraGO, Helvetica, sans-serif !important',
     fontSize: 12,
     width: '100%',
+    lineHeight: 1.33,
   }),
 
   indicatorSeparator: () => ({


### PR DESCRIPTION
We need to specify line height as 12px for select placeholder container (as we do for other form components).

This is important because otherwise it will follow line height of whatever parent element so it will certainly look weird most of the time unlike the other form components that specify it