### PR TITLE
Fix Select "create new tag". label

### DIFF
--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -16,6 +16,10 @@ import { Option } from './types';
 
 export interface MultiSelectProps {
   /**
+   * Custom new tag label. Sets the text for the "create new ..." option in the menu.
+   */
+  addNewTagLabel?: string,
+  /**
    * Whether the selection is clearable.
    */
   clearable?: boolean,
@@ -142,6 +146,7 @@ export const createNewValue = (values: string[], options: MultiSelectProps['opti
  */
 const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProps) => {
   const {
+    addNewTagLabel = 'Create new tag',
     clearable = false,
     creatable = false,
     defaultValue = [],
@@ -225,7 +230,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             inputId={name}
             maxMenuHeight={264}
             noOptionsMessage={formatNoOptionsMessage}
-            formatCreateLabel={(inputValue) => `Create new tag "${inputValue}"`}
+            formatCreateLabel={(inputValue) => `${addNewTagLabel} "${inputValue}"`}
             closeMenuOnSelect={!keepMenuOnSelect}
             isMulti
             isSearchable

--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -16,10 +16,6 @@ import { Option } from './types';
 
 export interface MultiSelectProps {
   /**
-   * Custom new tag label. Sets the text for the "create new ..." option in the menu.
-   */
-  addNewTagLabel?: string,
-  /**
    * Whether the selection is clearable.
    */
   clearable?: boolean,
@@ -27,6 +23,10 @@ export interface MultiSelectProps {
    * Whether the user can create new options.
    */
   creatable?: boolean,
+  /**
+   * Create new tag label. Sets the text for the "create new ..." option in the menu.
+   */
+  createTagLabel?: string,
   /**
    * Sets a preselected options. Type: [ string | number ]
    */
@@ -146,9 +146,9 @@ export const createNewValue = (values: string[], options: MultiSelectProps['opti
  */
 const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProps) => {
   const {
-    addNewTagLabel = 'Create new tag',
     clearable = false,
     creatable = false,
+    createTagLabel = 'Create new tag',
     defaultValue = [],
     disabled = false,
     helperLabel = '',
@@ -230,7 +230,7 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
             inputId={name}
             maxMenuHeight={264}
             noOptionsMessage={formatNoOptionsMessage}
-            formatCreateLabel={(inputValue) => `${addNewTagLabel} "${inputValue}"`}
+            formatCreateLabel={(inputValue) => `${createTagLabel} "${inputValue}"`}
             closeMenuOnSelect={!keepMenuOnSelect}
             isMulti
             isSearchable

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -29,6 +29,10 @@ export type SingleSelectProps<ValueType = DefaultValueType> = {
    */
   creatable?: boolean;
   /**
+   * Create new tag label. Sets the text for the "create new ..." option in the menu.
+   */
+  createTagLabel?: string,
+  /**
    * Sets a preselected option.
    */
   defaultValue?: SingleSelectOption<ValueType>;
@@ -156,6 +160,7 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
   placeholder = '',
   name = '',
   creatable = false,
+  createTagLabel = 'Create new tag',
   disabled = false,
   invalid = false,
   loading = false,
@@ -206,7 +211,7 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
     maxMenuHeight: maxMenuHeight,
     noOptionsMessage: () => 'no matches found',
     filterOption: defaultFilterOption,
-    formatCreateLabel: creatable ? (inputValue: string) => `Create new tag "${inputValue}"` : undefined,
+    formatCreateLabel: creatable ? (inputValue: string) => `${createTagLabel} "${inputValue}"` : undefined,
     isSearchable: creatable ? true : searchable,
     blurInputOnSelect: true,
     escapeClearsValue: true,


### PR DESCRIPTION
As discussed, extended the scope to include single select as both multi and single select implement the creatable prop which allows for the addition of new tags.

<img width="1015" alt="Screenshot 2022-01-26 at 07 52 23" src="https://user-images.githubusercontent.com/12200093/151123836-f95a5f9d-6922-4463-8e90-da8e4ff09f81.png">

