### PR TITLE
Don't show "no match found"

### DIFF
--- a/pyrene/src/components/MultiSelect/MultiSelect.tsx
+++ b/pyrene/src/components/MultiSelect/MultiSelect.tsx
@@ -192,9 +192,12 @@ const MultiSelect: FunctionComponent<MultiSelectProps> = (props: MultiSelectProp
   };
 
   const formatNoOptionsMessage: SelectProps<Option, true>['noOptionsMessage'] = (input) => {
-    const existingLabels = value.map((v) => v.label);
-    const foundLabel = existingLabels.find((v) => v.toLowerCase() === input.inputValue.toLowerCase());
-    return foundLabel ? `Duplicate tag "${foundLabel}"` : 'No matches found';
+    if (value && value.length > 0) {
+      const existingLabels = value.map((v) => v.label);
+      const foundLabel = existingLabels.find((v) => v.toLowerCase() === input.inputValue.toLowerCase());
+      return foundLabel ? `Duplicate tag "${foundLabel}"` : 'No matches found';
+    }
+    return null;
   };
 
   return (

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -209,7 +209,7 @@ const SingleSelect = <ValueType extends unknown = DefaultValueType>({
     autoFocus: autoFocus,
     openMenuOnFocus: openMenuOnFocus,
     maxMenuHeight: maxMenuHeight,
-    noOptionsMessage: () => 'no matches found',
+    noOptionsMessage: () => (value ? 'no matches found' : null),
     filterOption: defaultFilterOption,
     formatCreateLabel: creatable ? (inputValue: string) => `${createTagLabel} "${inputValue}"` : undefined,
     isSearchable: creatable ? true : searchable,


### PR DESCRIPTION
Select component should not show "No match found" if Select component has no default options and is `creatable`.