### PR TITLE
Fix of SingleSelect clearing bug

### DIFF
--- a/pyrene/src/components/SingleSelect/SingleSelect.examples.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.examples.tsx
@@ -47,7 +47,7 @@ const testOptionsWithIcons = testOptions.map((option, i) => ({ ...option, iconPr
 type OptionType = SingleSelectOption<string>;
 
 interface State {
-  value: OptionType
+  value: OptionType | null;
 }
 
 const examples: Example<SingleSelectProps<string>, State> = {
@@ -56,8 +56,8 @@ const examples: Example<SingleSelectProps<string>, State> = {
     placeholder: 'Choose your favorite ice cream',
     helperLabel: 'Ice cream is delicious',
     options: testOptions,
-    onChange: (stateProvider: StateProvider<State>) => (value: OptionType) => stateProvider.setState({ value }),
-    value: (stateProvider: StateProvider<State>): OptionType => stateProvider.state.value,
+    onChange: (stateProvider: StateProvider<State>) => (value: OptionType | null) => value && stateProvider.setState({ value }),
+    value: (stateProvider: StateProvider<State>): OptionType | null => stateProvider.state.value,
   },
   examples: [
     {
@@ -66,8 +66,8 @@ const examples: Example<SingleSelectProps<string>, State> = {
         placeholder: 'Choose your favorite ice cream',
         helperLabel: 'Ice cream is delicious',
         options: testOptions,
-        onChange: (stateProvider: StateProvider<State>) => (value: OptionType) => stateProvider.setState({ value }),
-        value: (stateProvider: StateProvider<State>): OptionType => stateProvider.state.value,
+        onChange: (stateProvider: StateProvider<State>) => (value: OptionType | null) => value && stateProvider.setState({ value }),
+        value: (stateProvider: StateProvider<State>): OptionType | null => stateProvider.state.value,
       },
       description: 'Simple Single Select',
     },
@@ -77,8 +77,8 @@ const examples: Example<SingleSelectProps<string>, State> = {
         placeholder: 'Choose your favorite ice cream',
         helperLabel: 'Ice cream is delicious',
         options: testOptionsWithIcons,
-        onChange: (stateProvider: StateProvider<State>) => (value: OptionType) => stateProvider.setState({ value }),
-        value: (stateProvider: StateProvider<State>): OptionType => stateProvider.state.value,
+        onChange: (stateProvider: StateProvider<State>) => (value: OptionType | null) => stateProvider.setState({ value }),
+        value: (stateProvider: StateProvider<State>): OptionType | null => stateProvider.state.value,
       },
       description: 'Single Select with Icons',
     },
@@ -89,8 +89,8 @@ const examples: Example<SingleSelectProps<string>, State> = {
         helperLabel: 'Ice cream is delicious',
         options: testOptions,
         searchable: true,
-        onChange: (stateProvider: StateProvider<State>) => (value: SingleSelectOption<string>) => stateProvider.setState({ value }),
-        value: (stateProvider: StateProvider<State>): SingleSelectOption<string> => stateProvider.state.value,
+        onChange: (stateProvider: StateProvider<State>) => (value: SingleSelectOption<string> | null) => stateProvider.setState({ value }),
+        value: (stateProvider: StateProvider<State>): SingleSelectOption<string> | null => stateProvider.state.value,
       },
       description: 'Single Select with search',
     },

--- a/pyrene/src/components/SingleSelect/SingleSelect.tsx
+++ b/pyrene/src/components/SingleSelect/SingleSelect.tsx
@@ -86,7 +86,7 @@ export type SingleSelectProps<ValueType = DefaultValueType> = {
   /**
    * Event Handler. Param option: {value: , label:}
    */
-  onChange?: (option: SingleSelectOption<ValueType>, evt: { target: { type: string; name: string; value: SingleSelectOption<ValueType> } }) => void;
+  onChange?: (option: SingleSelectOption<ValueType> | null, evt: { target: { type: string; name: string; value: SingleSelectOption<ValueType> } }) => void;
   /**
    * Focus event handler, use this to dynamically fetch options.
    */
@@ -111,7 +111,7 @@ export type SingleSelectProps<ValueType = DefaultValueType> = {
 
   title?: string;
 
-  value?: SingleSelectOption<ValueType>
+  value?: SingleSelectOption<ValueType> | null;
 };
 
 const sortOptions = <ValueType extends unknown>(options: SingleSelectOption<ValueType>[]) => {


### PR DESCRIPTION
Extending the `SingleSelect` `value` property to support `null`.

This is useful for the case where we want to reset the value from another component (a button for example).

See the example component below (implemented in Storybook), containing a `SingleSelect` and a `Button` component:
When clicking on the button, we want the selected value to be cleared.


https://user-images.githubusercontent.com/15834481/151189454-8a42eeea-0160-4317-83ff-1d24d11a53bb.mov



(The example component is not part of this PR.)
