### PR TITLE
Multiselect input delimiter

### DIFF
--- a/pyrene/src/components/MultiSelect/MultiSelect.examples.ts
+++ b/pyrene/src/components/MultiSelect/MultiSelect.examples.ts
@@ -48,6 +48,7 @@ const testOptionsWithIcons = testOptions.map((option, i) => ({ ...option, iconPr
 
 const makeExample = (options: ReadonlyArray<Option>) => ({
   title: 'Multi-Select',
+  customDelimiters: ['\\s', ',', ';', '?'],
   placeholder: 'Choose your favorite ice cream',
   helperLabel: 'Ice cream is delicious',
   options,

--- a/pyrene/src/components/MultiSelect/delimiterUtil.spec.js
+++ b/pyrene/src/components/MultiSelect/delimiterUtil.spec.js
@@ -15,6 +15,19 @@ describe('getDelimitedValues()', () => {
     expect(delimitedValues3).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
   });
 
+  it('delimits entries with custom delimiters', () => {
+    const customDelimiters = ['\\s', ',', '?', ';'];
+    const rawString1 = 'Banana Mango, Beer?Beer';
+    const rawString2 = 'Banana, Mango, Beer, Beer';
+    const rawString3 = 'Banana;Mango;Beer;Beer';
+    const delimitedValues1 = getDelimitedValues(rawString1, getRegExp(customDelimiters));
+    const delimitedValues2 = getDelimitedValues(rawString2, getRegExp(customDelimiters));
+    const delimitedValues3 = getDelimitedValues(rawString3, getRegExp(customDelimiters));
+    expect(delimitedValues1).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
+    expect(delimitedValues2).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
+    expect(delimitedValues3).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
+  });
+
   it('considers as single entry when there no delimiter is found in string', () => {
     const rawString = 'A tasty mango';
     const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));

--- a/pyrene/src/components/MultiSelect/delimiterUtil.spec.js
+++ b/pyrene/src/components/MultiSelect/delimiterUtil.spec.js
@@ -1,13 +1,15 @@
-import { getDelimitedValues, getCaseInsensitiveDistinctValues } from './delimiterUtil';
+import {
+  getDelimitedValues, getCaseInsensitiveDistinctValues, getRegExp, DEFAULT_DELIMITERS,
+} from './delimiterUtil';
 
 describe('getDelimitedValues()', () => {
   it('delimits entries with multiple delimiters', () => {
     const rawString1 = 'Banana\nMango\nBeer\nBeer';
     const rawString2 = 'Banana\tMango\tBeer\tBeer';
     const rawString3 = 'Banana\nMango\tBeer\nBeer';
-    const delimitedValues1 = getDelimitedValues(rawString1);
-    const delimitedValues2 = getDelimitedValues(rawString2);
-    const delimitedValues3 = getDelimitedValues(rawString3);
+    const delimitedValues1 = getDelimitedValues(rawString1, getRegExp(DEFAULT_DELIMITERS));
+    const delimitedValues2 = getDelimitedValues(rawString2, getRegExp(DEFAULT_DELIMITERS));
+    const delimitedValues3 = getDelimitedValues(rawString3, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues1).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
     expect(delimitedValues2).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
     expect(delimitedValues3).toStrictEqual(['Banana', 'Mango', 'Beer', 'Beer']);
@@ -15,31 +17,31 @@ describe('getDelimitedValues()', () => {
 
   it('considers as single entry when there no delimiter is found in string', () => {
     const rawString = 'A tasty mango';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues).toStrictEqual(['A tasty mango']);
   });
 
   it('removes beginning and trailing spaces', () => {
     const rawString = '    Ice-cream\nChocolate\t     ';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues).toStrictEqual(['Ice-cream', 'Chocolate']);
   });
 
   it('filters away empty strings', () => {
     const rawString = 'Banana\n\tMango\n\tBeer';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues).toStrictEqual(['Banana', 'Mango', 'Beer']);
   });
 
   it('returns empty array when string contains nothing', () => {
     const rawString = '';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues).toStrictEqual([]);
   });
 
   it('returns empty array when string contains only delimiters', () => {
     const rawString = '\n\t\t\n';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     expect(delimitedValues).toStrictEqual([]);
   });
 });
@@ -47,28 +49,28 @@ describe('getDelimitedValues()', () => {
 describe('getCaseInsensitiveDistinctValues()', () => {
   it('gets only distinct values', () => {
     const rawString = 'Banana\tMango\nBeer\nBeer';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     const distinctValues = getCaseInsensitiveDistinctValues(delimitedValues);
     expect(distinctValues).toStrictEqual(['Banana', 'Mango', 'Beer']);
   });
 
   it('returns single entry array when string contains repetitive characters but no delimiter', () => {
     const rawString = 'MangoMangoMango MangoMango';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     const distinctValues = getCaseInsensitiveDistinctValues(delimitedValues);
     expect(distinctValues).toStrictEqual(['MangoMangoMango MangoMango']);
   });
 
   it('returns empty array when string contains nothing', () => {
     const rawString = '';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     const distinctValues = getCaseInsensitiveDistinctValues(delimitedValues);
     expect(distinctValues).toStrictEqual([]);
   });
 
   it('returns empty array when string contains only delimiters', () => {
     const rawString = '\n\n\t\t';
-    const delimitedValues = getDelimitedValues(rawString);
+    const delimitedValues = getDelimitedValues(rawString, getRegExp(DEFAULT_DELIMITERS));
     const distinctValues = getCaseInsensitiveDistinctValues(delimitedValues);
     expect(distinctValues).toStrictEqual([]);
   });

--- a/pyrene/src/components/MultiSelect/delimiterUtil.ts
+++ b/pyrene/src/components/MultiSelect/delimiterUtil.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-const DEFAULT_DELIMITERS = ['\n', '\t'];
+export const DEFAULT_DELIMITERS = ['\n', '\t'];
 
 /**
  * Creates a unique array of string case insensitively.
@@ -13,13 +13,39 @@ export const getCaseInsensitiveDistinctValues = (words: string[]) => words.reduc
   return result;
 }, [] as string[]);
 
+/**
+ * Returns a RegExp object used to match a text with a pattern
+ * @param {string[]} regexStringArray - Array of regex string delimiters
+ * @returns {RegExp}
+ */
+export const getRegExp = (regexStringArray: Array<string>) => new RegExp(`\\s*[${regexStringArray.join('|')}]\\s*`);
+
 
 /**
  * Get delimited string values from a string.
  * @param {string} text - the raw string containing delimiter symbols
+ * @param {RegExp} delimiterRegx - RegExp object used to filter
  * @returns {string[]}
  */
-export const getDelimitedValues = (text: string) => {
-  const delimiterRegx = new RegExp(`\\s*[${DEFAULT_DELIMITERS.join('|')}]\\s*`);
-  return text.trim().split(delimiterRegx).filter((v) => v.length > 0);
+export const getDelimitedValues = (text: string, delimiterRegx: RegExp) => text.trim().split(delimiterRegx).filter((v) => v.length > 0);
+
+/**
+ * Checks if a KeyboardEvent contains a delimiter and returns an Enter key event if it does.
+ * @param {RegExp} delimiterRegexObj - Delimiter regex used for testing
+ * @param {React.KeyboardEvent<HTMLElement>} key - KeyboardEvent to check
+ * @returns {React.KeyboardEvent<HTMLElement>}
+ */
+export const delimiterCheck = (key: React.KeyboardEvent<HTMLElement>, delimiterRegexObj: RegExp) => {
+  if (delimiterRegexObj.test(key.key)) {
+    key.preventDefault();
+    key.currentTarget.dispatchEvent(new KeyboardEvent('keydown', {
+      code: 'Enter',
+      key: 'Enter',
+      charCode: 13,
+      keyCode: 13,
+      view: window,
+      bubbles: true,
+    }));
+  }
+  return key;
 };


### PR DESCRIPTION
Keep Default delimiters still as it is now.

Implement a prop such as `customDelimiters: ['\\s', ',', ';', '?']`

We want to make sure a user can type in 

- something, somethingelse and have 2 entries
- something somethingelse and have 2 entries